### PR TITLE
Adds SQLite syntax

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,11 +10,18 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.62.0
       - uses: actions-rs/cargo@v1
+        name: Test standard syntax
         with:
           command: test
       - uses: actions-rs/cargo@v1
+        name: Test PostgreSQL syntax
         with:
           command: test
-          args: --features postgresql --test feature_flag_postgresql
+          args: --features postgresql
+      - uses: actions-rs/cargo@v1
+        name: Test SQLite syntax
+        with:
+          command: test
+          args: --features sqlite

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,7 @@
 {
   "recommendations": [
-    "rust-lang.rust-analyzer"
+    "rust-lang.rust-analyzer",
+    "serayuzgur.crates",
+    "tamasfe.even-better-toml",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
   "rust-analyzer.diagnostics.disabled": [
     "inactive-code"
   ],
-  "rust-analyzer.cargo.features": [
-    "postgresql"
+  "rust-analyzer.cargo.features": [],
+  "rust-analyzer.linkedProjects": [
+    "./Cargo.toml"
   ],
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,18 @@ description = "Write SQL queries in a simple and composable way"
 documentation = "https://docs.rs/sql_query_builder"
 repository = "https://github.com/belchior/sql_query_builder"
 authors = ["Belchior Oliveira <belchior@outlook.com>"]
-version = "1.1.4"
+version = "2.0.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.62"
 license = "MIT"
-keywords = ["sql", "query", "postgres"]
+keywords = ["sql", "query", "postgres", "sqlite"]
 
 [features]
 postgresql = []
+sqlite = []
 
 [package.metadata.docs.rs]
-features = ["postgresql"]
+features = ["postgresql", "sqlite"]
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ SELECT id, login FROM users WHERE login = $1 AND is_admin = true
 
 SQL Query Builder comes with the following optional features:
 - `postgresql` enable Postgres syntax
+- `sqlite` enable SQLite syntax
 
 You can enable features like
 
 ```toml
 ## Cargo.toml
 
-sql_query_builder = { version = "1.x.x", features = ["postgresql"] }
+sql_query_builder = { version = "2.x.x", features = ["postgresql"] }
 ```
 
 
@@ -68,7 +69,7 @@ let select = sql::Select::new()
 
 Methods like `limit` and `offset` will override the previous value, the two select is equivalent
 
-```text
+```ts
 use sql_query_builder as sql;
 
 let select = sql::Select::new()
@@ -154,7 +155,7 @@ let query = Some(sql::Select::new())
 println!("{}", query);
 ```
 
-Output (indented for redability)
+Output (indented for readability)
 
 ```sql
 SELECT u.id, u.name as user_name, u.login, a.name as address_name, o.name as product_name
@@ -167,7 +168,7 @@ WHERE u.login = $1 AND o.id = $2
 
 ## Raw queries
 
-You can use the raw method to accomplish some edge cases that are hard to rewrite into the Select syntax.
+You can use the raw method to reach some edge cases that are hard to rewrite into the Select syntax.
 The `select.raw()` method will put any SQL you define on top of the output
 
 ```rust
@@ -213,7 +214,7 @@ let select = sql::Select::new()
 
 ## Debugging queries
 
-Sometimes it's more ease just print de current state of the query builder, to do this just add the .debug() method at any part of the builder, note that the where clause will not be printed because the debug was added before
+Sometimes it's more ease just print de current state of the query builder, to do so adds the `.debug()` method anywhere in the builder. In the example below, the where clause will not be printed because the debug was added before the clause
 
 ```rust
 use sql_query_builder as sql;
@@ -228,8 +229,10 @@ let mut select = sql::Select::new()
 Output
 
 ```sql
+-- ------------------------------------------------------------------------------
 SELECT id, login
 FROM users
+-- ------------------------------------------------------------------------------
 ```
 
 See the [documentation](https://docs.rs/sql_query_builder/) for more builders like [Insert](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Insert.html), [Update](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Update.html) and [Delete](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Delete.html)

--- a/scripts/coverage_test.sh
+++ b/scripts/coverage_test.sh
@@ -11,9 +11,11 @@ COVERAGE_TARGET="target/coverage"
 rm -fr "$COVERAGE_TARGET"
 mkdir -p "$COVERAGE_OUTPUT"
 mkdir -p "$COVERAGE_TARGET"
+clear
 
 RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET;
-RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features postgresql --test feature_flag_postgresql;
+RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features postgresql;
+RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features sqlite;
 
 cargo profdata -- merge -sparse $COVERAGE_TARGET/$PKG_NAME-*.profraw -o $COVERAGE_TARGET/$PKG_NAME.profdata;
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,5 @@
 
 clear
 cargo test
-cargo test --features postgresql --test feature_flag_postgresql
+cargo test --features postgresql
+cargo test --features sqlite

--- a/scripts/watch_test.sh
+++ b/scripts/watch_test.sh
@@ -3,5 +3,21 @@
 # Prerequisites
 # cargo install cargo-watch
 
+# Usage
+# ./scripts/watch_test.sh            # will run without enable feature
+# ./scripts/watch_test.sh all        # will enable all feature
+# ./scripts/watch_test.sh postgresql # will enable only the postgresql feature
+
+all_features='postgresql sqlite'
+features=''
+
+case "$@" in
+  "")    features="";;
+  "all") features="$all_features";;
+  *)     features="$@";;
+esac
+
+[ ! -z "$features" ] && features="--features $features"
+
 # cargo watch -w ./src -w ./tests -x 'test --features postgresql -- --nocapture --color always'
-cargo watch -w ./src -w ./tests -x 'test --features postgresql'
+cargo watch -w ./src -w ./tests -x "test $features"

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -1,4 +1,6 @@
 use crate::fmt;
+#[cfg(feature = "sqlite")]
+use crate::structure::{InsertClause, InsertVars, UpdateClause, UpdateVars};
 use std::cmp::PartialEq;
 
 pub trait Concat {
@@ -78,8 +80,8 @@ pub trait ConcatSqlStandard<Clause: PartialEq> {
   }
 }
 
-#[cfg(feature = "postgresql")]
-pub trait ConcatPostgres<Clause: PartialEq> {
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+pub trait ConcatCommon<Clause: PartialEq> {
   fn concat_returning(
     &self,
     items_raw_before: &Vec<(Clause, String)>,
@@ -134,6 +136,104 @@ pub trait ConcatPostgres<Clause: PartialEq> {
       let with = &with[..with.len() - comma.len() - lb.len()];
 
       format!("WITH{space}{lb}{with}{space}{lb}")
+    } else {
+      "".to_owned()
+    };
+
+    concat_raw_before_after(items_raw_before, items_raw_after, query, fmts, clause, sql)
+  }
+}
+
+#[cfg(feature = "sqlite")]
+pub trait ConcatSqlite {
+  fn concat_insert(
+    &self,
+    items_raw_before: &Vec<(InsertClause, String)>,
+    items_raw_after: &Vec<(InsertClause, String)>,
+    query: String,
+    fmts: &fmt::Formatter,
+    insert: &(InsertVars, String),
+  ) -> String {
+    let fmt::Formatter { lb, space, .. } = fmts;
+
+    let (clause, sql) = match insert {
+      (InsertVars::InsertInto, exp) if exp.is_empty() => (InsertClause::InsertInto, "".to_owned()),
+      (InsertVars::InsertInto, exp) => (InsertClause::InsertInto, format!("INSERT INTO{space}{exp}{space}{lb}")),
+
+      (InsertVars::InsertOr, exp) if exp.is_empty() => (InsertClause::InsertOr, "".to_owned()),
+      (InsertVars::InsertOr, exp) => (InsertClause::InsertOr, format!("INSERT OR{space}{exp}{space}{lb}")),
+
+      (InsertVars::ReplaceInto, exp) if exp.is_empty() => (InsertClause::ReplaceInto, "".to_owned()),
+      (InsertVars::ReplaceInto, exp) => (
+        InsertClause::ReplaceInto,
+        format!("REPLACE INTO{space}{exp}{space}{lb}"),
+      ),
+    };
+
+    concat_raw_before_after(items_raw_before, items_raw_after, query, fmts, clause, sql)
+  }
+
+  fn concat_join<Clause: PartialEq>(
+    &self,
+    items_raw_before: &Vec<(Clause, String)>,
+    items_raw_after: &Vec<(Clause, String)>,
+    query: String,
+    fmts: &fmt::Formatter,
+    clause: Clause,
+    join: &Vec<String>,
+  ) -> String {
+    let fmt::Formatter { lb, space, .. } = fmts;
+    let sql = if join.is_empty() == false {
+      let joins = join.join(format!("{space}{lb}").as_str());
+      format!("{joins}{space}{lb}")
+    } else {
+      "".to_owned()
+    };
+
+    concat_raw_before_after(&items_raw_before, &items_raw_after, query, fmts, clause, sql)
+  }
+
+  fn concat_update(
+    &self,
+    items_raw_before: &Vec<(UpdateClause, String)>,
+    items_raw_after: &Vec<(UpdateClause, String)>,
+    query: String,
+    fmts: &fmt::Formatter,
+    update: &(UpdateVars, String),
+  ) -> String {
+    let fmt::Formatter { lb, space, .. } = fmts;
+    let (clause, sql) = match update {
+      (UpdateVars::Update, table_name) if table_name.is_empty() => (UpdateClause::Update, "".to_string()),
+      (UpdateVars::Update, table_name) => (UpdateClause::Update, format!("UPDATE{space}{table_name}{space}{lb}")),
+
+      (UpdateVars::UpdateOr, expression) if expression.is_empty() => (UpdateClause::UpdateOr, "".to_string()),
+      (UpdateVars::UpdateOr, expression) => (
+        UpdateClause::UpdateOr,
+        format!("UPDATE OR{space}{expression}{space}{lb}"),
+      ),
+    };
+
+    concat_raw_before_after(items_raw_before, items_raw_after, query, fmts, clause, sql)
+  }
+
+  fn concat_values<Clause: PartialEq>(
+    &self,
+    items_raw_before: &Vec<(Clause, String)>,
+    items_raw_after: &Vec<(Clause, String)>,
+    query: String,
+    fmts: &fmt::Formatter,
+    clause: Clause,
+    values: &Vec<String>,
+    default_values: &bool,
+  ) -> String {
+    let fmt::Formatter { comma, lb, space, .. } = fmts;
+
+    let sql = if *default_values {
+      format!("DEFAULT VALUES{space}{lb}")
+    } else if values.is_empty() == false {
+      let sep = format!("{comma}{lb}");
+      let values = values.join(&sep);
+      format!("VALUES{space}{lb}{values}{space}{lb}")
     } else {
       "".to_owned()
     };

--- a/src/delete/delete.rs
+++ b/src/delete/delete.rs
@@ -4,6 +4,10 @@ use crate::{
   structure::{Delete, DeleteClause},
 };
 
+impl WithQuery for Delete {}
+
+impl TransactionQuery for Delete {}
+
 impl Delete {
   /// The same as [where_clause](Delete::where_clause) method, useful to write more idiomatic SQL query
   ///
@@ -197,19 +201,19 @@ impl Delete {
   }
 }
 
-#[cfg(any(doc, feature = "postgresql"))]
+#[cfg(any(doc, feature = "postgresql", feature = "sqlite"))]
 impl Delete {
-  /// The `returning` clause, this method can be used enabling the feature flag `postgresql`
+  /// The `returning` clause, this method can be used enabling a feature flag
   pub fn returning(mut self, output_name: &str) -> Self {
     push_unique(&mut self._returning, output_name.trim().to_owned());
     self
   }
 
-  /// The `with` clause, this method can be used enabling the feature flag `postgresql`
+  /// The `with` clause, this method can be used enabling a feature flag
   ///
   /// # Example
   ///
-  /// ```text
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let deactivated_users = sql::Select::new().select("id").from("users").where_clause("ative = false");
@@ -236,10 +240,6 @@ impl Delete {
     self
   }
 }
-
-impl WithQuery for Delete {}
-
-impl TransactionQuery for Delete {}
 
 impl std::fmt::Display for Delete {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/delete/delete_internal.rs
+++ b/src/delete/delete_internal.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "postgresql")]
-use crate::behavior::ConcatPostgres;
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+use crate::behavior::ConcatCommon;
 use crate::{
   behavior::{concat_raw_before_after, Concat, ConcatSqlStandard},
   fmt,
@@ -7,9 +7,6 @@ use crate::{
 };
 
 impl ConcatSqlStandard<DeleteClause> for Delete {}
-
-#[cfg(feature = "postgresql")]
-impl ConcatPostgres<DeleteClause> for Delete {}
 
 impl Delete {
   fn concat_delete_from(&self, query: String, fmts: &fmt::Formatter) -> String {
@@ -37,7 +34,7 @@ impl Concat for Delete {
     let mut query = "".to_owned();
 
     query = self.concat_raw(query, &fmts, &self._raw);
-    #[cfg(feature = "postgresql")]
+    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
     {
       query = self.concat_with(
         &self._raw_before,
@@ -57,7 +54,7 @@ impl Concat for Delete {
       DeleteClause::Where,
       &self._where,
     );
-    #[cfg(feature = "postgresql")]
+    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
     {
       query = self.concat_returning(
         &self._raw_before,
@@ -72,3 +69,6 @@ impl Concat for Delete {
     query.trim_end().to_owned()
   }
 }
+
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+impl ConcatCommon<DeleteClause> for Delete {}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -27,11 +27,12 @@ pub fn multiline<'a>() -> Formatter<'a> {
 }
 
 pub fn colorize(query: String) -> String {
-  let sql_syntax: [(fn(&str) -> String, &str, &str); 61] = [
+  let sql_syntax: [(fn(&str) -> String, &str, &str); 64] = [
     (blue, "AND ", "and "),
     (blue, "COMMIT", "commit"),
     (blue, "CROSS ", "cross "),
     (blue, "DELETE ", "delete "),
+    (blue, "END ", "end "),
     (blue, "EXCEPT ", "except "),
     (blue, "FROM ", "from "),
     (blue, "FULL ", "full "),
@@ -51,6 +52,7 @@ pub fn colorize(query: String) -> String {
     (blue, "READ ONLY", "read only"),
     (blue, "READ WRITE", "read write"),
     (blue, "RELEASE ", "release "),
+    (blue, "REPLACE ", "REPLACE "),
     (blue, "RETURNING ", "returning "),
     (blue, "RIGHT ", "right "),
     (blue, "ROLLBACK", "rollback"),
@@ -70,6 +72,7 @@ pub fn colorize(query: String) -> String {
     (blue, " BY", " by"),
     (blue, " COMMITTED", " committed"),
     (blue, " CONFLICT", " conflict"),
+    (blue, " DEFAULT", " default"),
     (blue, " DEFERRABLE", " deferrable"),
     (blue, " DESC", " desc"),
     (blue, " DO", " do"),

--- a/src/select/select.rs
+++ b/src/select/select.rs
@@ -4,6 +4,10 @@ use crate::{
   structure::{Select, SelectClause},
 };
 
+impl TransactionQuery for Select {}
+
+impl WithQuery for Select {}
+
 impl Select {
   /// The same as [where_clause](Select::where_clause) method, useful to write more idiomatic SQL query
   ///
@@ -270,25 +274,25 @@ impl Select {
   }
 }
 
-#[cfg(any(doc, feature = "postgresql"))]
+#[cfg(any(doc, feature = "postgresql", feature = "sqlite"))]
 impl Select {
-  /// The `except` clause, this method can be used enabling the feature flag `postgresql`
+  /// The `except` clause, this method can be used enabling a feature flag
   pub fn except(mut self, select: Self) -> Self {
     self._except.push(select);
     self
   }
 
-  /// The `intersect` clause, this method can be used enabling the feature flag `postgresql`
+  /// The `intersect` clause, this method can be used enabling a feature flag
   pub fn intersect(mut self, select: Self) -> Self {
     self._intersect.push(select);
     self
   }
 
-  /// The `limit` clause, this method overrides the previous value, this method can be used enabling the feature flag `postgresql`
+  /// The `limit` clause, this method overrides the previous value, this method can be used enabling a feature flag
   ///
   /// # Example
   ///
-  /// ```text
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let select = sql::Select::new()
@@ -303,11 +307,11 @@ impl Select {
     self
   }
 
-  /// The `offset` clause, this method overrides the previous value, this method can be used enabling the feature flag `postgresql`
+  /// The `offset` clause, this method overrides the previous value, this method can be used enabling a feature flag
   ///
   /// # Example
   ///
-  /// ```text
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let select = sql::Select::new()
@@ -322,17 +326,17 @@ impl Select {
     self
   }
 
-  /// The `union` clause, this method can be used enabling the feature flag `postgresql`
+  /// The `union` clause, this method can be used enabling a feature flag
   pub fn union(mut self, select: Self) -> Self {
     self._union.push(select);
     self
   }
 
-  /// The `with` clause, this method can be used enabling the feature flag `postgresql`
+  /// The `with` clause, this method can be used enabling a feature flag
   ///
   /// # Example
   ///
-  /// ```text
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let logins = sql::Select::new().select("login").from("users").where_clause("id in ($1)");
@@ -361,10 +365,6 @@ impl Select {
     self
   }
 }
-
-impl WithQuery for Select {}
-
-impl TransactionQuery for Select {}
 
 impl std::fmt::Display for Select {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/select/select_internal.rs
+++ b/src/select/select_internal.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "postgresql")]
-use crate::behavior::ConcatPostgres;
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+use crate::behavior::ConcatCommon;
 use crate::{
   behavior::{concat_raw_before_after, Concat, ConcatSqlStandard},
   fmt,
@@ -8,94 +8,60 @@ use crate::{
 
 impl ConcatSqlStandard<SelectClause> for Select {}
 
-#[cfg(feature = "postgresql")]
-impl ConcatPostgres<SelectClause> for Select {}
+impl Concat for Select {
+  fn concat(&self, fmts: &fmt::Formatter) -> String {
+    let mut query = "".to_owned();
 
-#[cfg(feature = "postgresql")]
-impl Select {
-  fn concat_combinator(
-    &self,
-    query: String,
-    fmts: &fmt::Formatter,
-    combinator: crate::structure::Combinator,
-  ) -> String {
-    use crate::behavior::raw_queries;
-    use crate::structure::Combinator;
+    query = self.concat_raw(query, &fmts, &self._raw);
 
-    let fmt::Formatter { lb, space, .. } = fmts;
-    let (clause, clause_name, clause_list) = match combinator {
-      Combinator::Except => (SelectClause::Except, "EXCEPT", &self._except),
-      Combinator::Intersect => (SelectClause::Intersect, "INTERSECT", &self._intersect),
-      Combinator::Union => (SelectClause::Union, "UNION", &self._union),
-    };
+    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+    {
+      query = self.concat_with(
+        &self._raw_before,
+        &self._raw_after,
+        query,
+        &fmts,
+        SelectClause::With,
+        &self._with,
+      );
+    }
+    query = self.concat_select(query, &fmts);
+    query = self.concat_from(
+      &self._raw_before,
+      &self._raw_after,
+      query,
+      &fmts,
+      SelectClause::From,
+      &self._from,
+    );
+    query = self.concat_join(query, &fmts);
+    query = self.concat_where(
+      &self._raw_before,
+      &self._raw_after,
+      query,
+      &fmts,
+      SelectClause::Where,
+      &self._where,
+    );
+    query = self.concat_group_by(query, &fmts);
+    query = self.concat_having(query, &fmts);
+    query = self.concat_order_by(query, &fmts);
 
-    let raw_before = raw_queries(&self._raw_before, &clause).join(space);
-    let raw_after = raw_queries(&self._raw_after, &clause).join(space);
-
-    let space_before = if raw_before.is_empty() {
-      "".to_owned()
-    } else {
-      space.to_string()
-    };
-    let space_after = if raw_after.is_empty() {
-      "".to_owned()
-    } else {
-      space.to_string()
-    };
-
-    if clause_list.is_empty() {
-      let sql = "".to_owned();
-      return format!("{query}{raw_before}{space_before}{sql}{raw_after}{space_after}");
+    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+    {
+      query = self.concat_limit(query, &fmts);
+      query = self.concat_offset(query, &fmts);
     }
 
-    let right_stmt = clause_list.iter().fold("".to_owned(), |acc, select| {
-      let query = select.concat(&fmts);
-      format!("{acc}{clause_name}{space}({lb}{query}){space}{lb}")
-    });
+    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+    {
+      use crate::structure::Combinator;
+      query = self.concat_combinator(query, &fmts, Combinator::Except);
+      query = self.concat_combinator(query, &fmts, Combinator::Intersect);
+      query = self.concat_combinator(query, &fmts, Combinator::Union);
+    }
 
-    let query = query.trim_end();
-    let space_before = space;
-    let left_stmt = format!("({query}{raw_before}){space_before}");
-
-    format!("{left_stmt}{right_stmt}{raw_after}{space_after}")
-  }
-
-  fn concat_limit(&self, query: String, fmts: &fmt::Formatter) -> String {
-    let fmt::Formatter { lb, space, .. } = fmts;
-    let sql = if self._limit.is_empty() == false {
-      let count = &self._limit;
-      format!("LIMIT{space}{count}{space}{lb}")
-    } else {
-      "".to_owned()
-    };
-
-    concat_raw_before_after(
-      &self._raw_before,
-      &self._raw_after,
-      query,
-      fmts,
-      SelectClause::Limit,
-      sql,
-    )
-  }
-
-  fn concat_offset(&self, query: String, fmts: &fmt::Formatter) -> String {
-    let fmt::Formatter { lb, space, .. } = fmts;
-    let sql = if self._offset.is_empty() == false {
-      let start = &self._offset;
-      format!("OFFSET{space}{start}{space}{lb}")
-    } else {
-      "".to_owned()
-    };
-
-    concat_raw_before_after(
-      &self._raw_before,
-      &self._raw_after,
-      query,
-      fmts,
-      SelectClause::Offset,
-      sql,
-    )
+    query.trim_end().to_owned()
   }
 }
 
@@ -196,59 +162,96 @@ impl Select {
   }
 }
 
-impl Concat for Select {
-  fn concat(&self, fmts: &fmt::Formatter) -> String {
-    let mut query = "".to_owned();
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+impl ConcatCommon<SelectClause> for Select {}
 
-    query = self.concat_raw(query, &fmts, &self._raw);
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+impl Select {
+  fn concat_combinator(
+    &self,
+    query: String,
+    fmts: &fmt::Formatter,
+    combinator: crate::structure::Combinator,
+  ) -> String {
+    use crate::behavior::raw_queries;
+    use crate::structure::Combinator;
 
-    #[cfg(feature = "postgresql")]
-    {
-      query = self.concat_with(
-        &self._raw_before,
-        &self._raw_after,
-        query,
-        &fmts,
-        SelectClause::With,
-        &self._with,
-      );
+    let fmt::Formatter { lb, space, .. } = fmts;
+    let (clause, clause_name, clause_list) = match combinator {
+      Combinator::Except => (SelectClause::Except, "EXCEPT", &self._except),
+      Combinator::Intersect => (SelectClause::Intersect, "INTERSECT", &self._intersect),
+      Combinator::Union => (SelectClause::Union, "UNION", &self._union),
+    };
+
+    let raw_before = raw_queries(&self._raw_before, &clause).join(space);
+    let raw_after = raw_queries(&self._raw_after, &clause).join(space);
+
+    let space_before = if raw_before.is_empty() {
+      "".to_owned()
+    } else {
+      space.to_string()
+    };
+    let space_after = if raw_after.is_empty() {
+      "".to_owned()
+    } else {
+      space.to_string()
+    };
+
+    if clause_list.is_empty() {
+      let sql = "".to_owned();
+      return format!("{query}{raw_before}{space_before}{sql}{raw_after}{space_after}");
     }
-    query = self.concat_select(query, &fmts);
-    query = self.concat_from(
+
+    let right_stmt = clause_list.iter().fold("".to_owned(), |acc, select| {
+      let query = select.concat(&fmts);
+      format!("{acc}{clause_name}{space}({lb}{query}){space}{lb}")
+    });
+
+    let query = query.trim_end();
+    let space_before = space;
+    let left_stmt = format!("({query}{raw_before}){space_before}");
+
+    format!("{left_stmt}{right_stmt}{raw_after}{space_after}")
+  }
+
+  fn concat_limit(&self, query: String, fmts: &fmt::Formatter) -> String {
+    let fmt::Formatter { lb, space, .. } = fmts;
+    let sql = if self._limit.is_empty() == false {
+      let count = &self._limit;
+      format!("LIMIT{space}{count}{space}{lb}")
+    } else {
+      "".to_owned()
+    };
+
+    concat_raw_before_after(
       &self._raw_before,
       &self._raw_after,
       query,
-      &fmts,
-      SelectClause::From,
-      &self._from,
-    );
-    query = self.concat_join(query, &fmts);
-    query = self.concat_where(
+      fmts,
+      SelectClause::Limit,
+      sql,
+    )
+  }
+}
+
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+impl Select {
+  fn concat_offset(&self, query: String, fmts: &fmt::Formatter) -> String {
+    let fmt::Formatter { lb, space, .. } = fmts;
+    let sql = if self._offset.is_empty() == false {
+      let start = &self._offset;
+      format!("OFFSET{space}{start}{space}{lb}")
+    } else {
+      "".to_owned()
+    };
+
+    concat_raw_before_after(
       &self._raw_before,
       &self._raw_after,
       query,
-      &fmts,
-      SelectClause::Where,
-      &self._where,
-    );
-    query = self.concat_group_by(query, &fmts);
-    query = self.concat_having(query, &fmts);
-    query = self.concat_order_by(query, &fmts);
-
-    #[cfg(feature = "postgresql")]
-    {
-      query = self.concat_limit(query, &fmts);
-      query = self.concat_offset(query, &fmts);
-    }
-
-    #[cfg(feature = "postgresql")]
-    {
-      use crate::structure::Combinator;
-      query = self.concat_combinator(query, &fmts, Combinator::Except);
-      query = self.concat_combinator(query, &fmts, Combinator::Intersect);
-      query = self.concat_combinator(query, &fmts, Combinator::Union);
-    }
-
-    query.trim_end().to_owned()
+      fmts,
+      SelectClause::Offset,
+      sql,
+    )
   }
 }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -9,7 +9,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let query = sql::Transaction::new()
@@ -34,7 +34,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let query = sql::Transaction::new()
@@ -61,7 +61,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let insert_foo = sql::Insert::new()
@@ -95,7 +95,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let delete_foo = sql::Delete::new()
@@ -127,7 +127,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let insert_foo = sql::Insert::new()
@@ -286,7 +286,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let select_foo = sql::Select::new()
@@ -335,6 +335,7 @@ impl Transaction {
   /// START TRANSACTION;
   /// SET TRANSACTION read only;
   /// ```
+  #[cfg(not(feature = "sqlite"))]
   pub fn set_transaction(mut self, mode: &str) -> Self {
     let cmd = TransactionCommand::new(SetTransaction, mode.trim().to_owned());
     self._set_transaction = Some(cmd);
@@ -362,6 +363,7 @@ impl Transaction {
   /// START TRANSACTION isolation level serializable;
   /// COMMIT;
   /// ```
+  #[cfg(not(feature = "sqlite"))]
   pub fn start_transaction(mut self, mode: &str) -> Self {
     let cmd = TransactionCommand::new(StartTransaction, mode.trim().to_owned());
     self._start_transaction = Some(cmd);
@@ -372,7 +374,7 @@ impl Transaction {
   ///
   /// # Example
   ///
-  /// ```
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let update_foo = sql::Update::new()
@@ -401,20 +403,45 @@ impl Transaction {
   }
 }
 
-#[cfg(any(doc, feature = "postgresql"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
 impl Transaction {
   /// The `begin` command, this method will be always added at the beginning of the transation and
-  /// all consecutive call will override the previous value. The method can be used enabling the feature flag `postgresql`
+  /// all consecutive call will override the previous value. The method can be used enabling a feature flag
   ///
   /// # Example
   ///
-  /// ```text
+  /// ```ts
   /// use sql_query_builder as sql;
   ///
   /// let query = sql::Transaction::new()
+  ///   .begin("transaction")
   ///   .commit("")
-  ///   .begin("isolation level serializable")
+  ///   .as_string();
+  /// ```
+  ///
+  /// Output
+  ///
+  /// ```sql
+  /// BEGIN transaction;
+  /// COMMIT;
+  /// ```
+  pub fn begin(mut self, mode: &str) -> Self {
+    let cmd = TransactionCommand::new(Begin, mode.trim().to_owned());
+    self._begin = Some(cmd);
+    self
+  }
+
+  /// The `end` command, this method will be always added at the end of the transation and
+  /// all consecutive call will override the previous value. The method can be used enabling a feature flag
+  ///
+  /// # Example
+  ///
+  /// ```ts
+  /// use sql_query_builder as sql;
+  ///
+  /// let query = sql::Transaction::new()
   ///   .begin("")
+  ///   .end("")
   ///   .as_string();
   /// ```
   ///
@@ -422,11 +449,11 @@ impl Transaction {
   ///
   /// ```sql
   /// BEGIN;
-  /// COMMIT;
+  /// END;
   /// ```
-  pub fn begin(mut self, mode: &str) -> Self {
-    let cmd = TransactionCommand::new(Begin, mode.trim().to_owned());
-    self._begin = Some(cmd);
+  pub fn end(mut self, mode: &str) -> Self {
+    let cmd = TransactionCommand::new(End, mode.trim().to_owned());
+    self._end = Some(cmd);
     self
   }
 }

--- a/tests/feature_flag_sqlite.rs
+++ b/tests/feature_flag_sqlite.rs
@@ -1,0 +1,198 @@
+#[cfg(feature = "sqlite")]
+mod default_values_clause {
+  mod insert_builder {
+    use pretty_assertions::assert_eq;
+    use sql_query_builder as sql;
+
+    #[test]
+    fn method_default_values_should_add_the_default_values_clause() {
+      let query = sql::Insert::new()
+        .insert_into("users (login, name)")
+        .default_values()
+        .as_string();
+      let expected_query = "INSERT INTO users (login, name) DEFAULT VALUES";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_default_values_should_overrides_the_values_clause() {
+      let query = sql::Insert::new()
+        .insert_into("orders (product_name, price)")
+        .default_values()
+        .values("('Foo', 1234)")
+        .as_string();
+      let expected_query = "INSERT INTO orders (product_name, price) DEFAULT VALUES";
+
+      assert_eq!(query, expected_query);
+    }
+  }
+}
+
+#[cfg(feature = "sqlite")]
+mod insert_or_clause {
+  mod insert_builder {
+    use pretty_assertions::assert_eq;
+    use sql_query_builder as sql;
+
+    #[test]
+    fn method_insert_or_should_add_the_insert_or_clause() {
+      let query = sql::Insert::new()
+        .insert_or("ABORT INTO users (login, name)")
+        .as_string();
+      let expected_query = "INSERT OR ABORT INTO users (login, name)";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_insert_or_should_override_value_on_consecutive_calls() {
+      let query = sql::Insert::new()
+        .insert_or("FAIL INTO users (login, name)")
+        .insert_or("FAIL INTO orders (product_name, price)")
+        .as_string();
+      let expected_query = "INSERT OR FAIL INTO orders (product_name, price)";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_insert_or_should_trim_space_of_the_argument() {
+      let query = sql::Insert::new().insert_or("  IGNORE INTO users (name)  ").as_string();
+      let expected_query = "INSERT OR IGNORE INTO users (name)";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_raw_before_should_add_raw_sql_before_insert_or_clause() {
+      let query = sql::Insert::new()
+        .raw_before(sql::InsertClause::InsertOr, "/* insert or replace */")
+        .insert_or("REPLACE INTO users (login)")
+        .as_string();
+      let expected_query = "/* insert or replace */ INSERT OR REPLACE INTO users (login)";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_raw_after_should_add_raw_sql_after_insert_or_clause() {
+      let query = sql::Insert::new()
+        .insert_or("ROLLBACK INTO users (name)")
+        .raw_after(sql::InsertClause::InsertOr, "values ('foo')")
+        .as_string();
+      let expected_query = "INSERT OR ROLLBACK INTO users (name) values ('foo')";
+
+      assert_eq!(query, expected_query);
+    }
+  }
+}
+
+#[cfg(feature = "sqlite")]
+mod insert_variances {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn when_more_than_one_insert_variances_are_defined_the_last_one_should_overrides_the_previous_ones() {
+    let query = sql::Insert::new()
+      .insert_into("users (login, name)")
+      .insert_or("ABORT INTO users (login, name)")
+      .replace_into("users (login, name)")
+      .as_string();
+    let expected_query = "REPLACE INTO users (login, name)";
+    assert_eq!(query, expected_query);
+
+    let query = sql::Insert::new()
+      .replace_into("users (login, name)")
+      .insert_into("users (login, name)")
+      .insert_or("ABORT INTO users (login, name)")
+      .as_string();
+    let expected_query = "INSERT OR ABORT INTO users (login, name)";
+    assert_eq!(query, expected_query);
+
+    let query = sql::Insert::new()
+      .insert_or("ABORT INTO users (login, name)")
+      .replace_into("users (login, name)")
+      .insert_into("users (login, name)")
+      .as_string();
+    let expected_query = "INSERT INTO users (login, name)";
+    assert_eq!(query, expected_query);
+  }
+}
+
+#[cfg(feature = "sqlite")]
+mod update_or_clause {
+  mod update_builder {
+    use pretty_assertions::assert_eq;
+    use sql_query_builder as sql;
+
+    #[test]
+    fn method_update_or_should_add_the_update_or_clause() {
+      let query = sql::Update::new().update_or("ABORT users (login, name)").as_string();
+      let expected_query = "UPDATE OR ABORT users (login, name)";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_update_or_should_override_value_on_consecutive_calls() {
+      let query = sql::Update::new()
+        .update_or("FAIL users")
+        .update_or("IGNORE orders")
+        .as_string();
+      let expected_query = "UPDATE OR IGNORE orders";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn methods_update_and_update_or_should_override_each_other() {
+      let query = sql::Update::new()
+        .update("users")
+        .update_or("IGNORE orders")
+        .as_string();
+      let expected_query = "UPDATE OR IGNORE orders";
+
+      assert_eq!(query, expected_query);
+
+      let query = sql::Update::new()
+        .update_or("IGNORE orders")
+        .update("users")
+        .as_string();
+      let expected_query = "UPDATE users";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_update_or_should_trim_space_of_the_argument() {
+      let query = sql::Update::new().update_or("  REPLACE orders  ").as_string();
+      let expected_query = "UPDATE OR REPLACE orders";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_raw_before_should_add_raw_sql_before_update_or_clause() {
+      let query = sql::Update::new()
+        .raw_before(sql::UpdateClause::UpdateOr, "/* update_or users */")
+        .update_or("ROLLBACK users")
+        .as_string();
+      let expected_query = "/* update_or users */ UPDATE OR ROLLBACK users";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_raw_after_should_add_raw_sql_after_update_or_clause() {
+      let query = sql::Update::new()
+        .update_or("ABORT users")
+        .raw_after(sql::UpdateClause::UpdateOr, "set login = 'foo'")
+        .as_string();
+      let expected_query = "UPDATE OR ABORT users set login = 'foo'";
+
+      assert_eq!(query, expected_query);
+    }
+  }
+}

--- a/tests/insert_builder_api_spec.rs
+++ b/tests/insert_builder_api_spec.rs
@@ -114,8 +114,8 @@ mod insert_into_clause {
 
   #[test]
   fn method_insert_into_should_add_a_insert_into_clause() {
-    let query = sql::Insert::new().insert_into("users").as_string();
-    let expected_query = "INSERT INTO users";
+    let query = sql::Insert::new().insert_into("users (login, name)").as_string();
+    let expected_query = "INSERT INTO users (login, name)";
 
     assert_eq!(query, expected_query);
   }
@@ -123,10 +123,10 @@ mod insert_into_clause {
   #[test]
   fn method_insert_into_should_override_value_on_consecutive_calls() {
     let query = sql::Insert::new()
-      .insert_into("users")
-      .insert_into("orders")
+      .insert_into("users (login, name)")
+      .insert_into("orders (product_name, price)")
       .as_string();
-    let expected_query = "INSERT INTO orders";
+    let expected_query = "INSERT INTO orders (product_name, price)";
 
     assert_eq!(query, expected_query);
   }
@@ -162,6 +162,7 @@ mod insert_into_clause {
   }
 }
 
+#[cfg(not(feature = "sqlite"))]
 mod overriding_clause {
   use super::*;
   use pretty_assertions::assert_eq;

--- a/tests/insert_builder_features_spec.rs
+++ b/tests/insert_builder_features_spec.rs
@@ -19,12 +19,11 @@ fn insert_builder_should_be_displayable() {
 fn insert_builder_should_be_debuggable() {
   let insert = sql::Insert::new()
     .insert_into("users(login, name)")
-    .values("('foo', 'Foo')")
-    .overriding("user value");
+    .values("('foo', 'Foo')");
 
   println!("{:?}", insert);
 
-  let expected_query = "INSERT INTO users(login, name) OVERRIDING user value VALUES ('foo', 'Foo')";
+  let expected_query = "INSERT INTO users(login, name) VALUES ('foo', 'Foo')";
   let query = insert.as_string();
 
   assert_eq!(query, expected_query);
@@ -64,15 +63,15 @@ fn insert_builder_should_be_cloneable() {
 #[test]
 fn insert_builder_should_be_able_to_conditionally_add_clauses() {
   let mut insert = sql::Insert::new()
-    .insert_into("users(login, name)")
+    .insert_into("users (login, name)")
     .values("('bar', 'Bar')");
 
   if true {
-    insert = insert.overriding("system value");
+    insert = insert.values("('foo', 'Foo')");
   }
 
   let query = insert.as_string();
-  let expected_query = "INSERT INTO users(login, name) OVERRIDING system value VALUES ('bar', 'Bar')";
+  let expected_query = "INSERT INTO users (login, name) VALUES ('bar', 'Bar'), ('foo', 'Foo')";
 
   assert_eq!(query, expected_query);
 }


### PR DESCRIPTION
## Breaking changes
This PR setup the minimum rust version to [1.62.0](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)

## New features
Adds SQLite syntax support, you can enable it using

```toml
# Cargo.toml

sql_query_builder = { version = "2.x.x", features = ["sqlite"] }
```

The current release adds suppport for the following commands
- crud operations with: [select](https://sqlite.org/lang_select.html), [insert](https://sqlite.org/lang_insert.html), [update](https://sqlite.org/lang_update.html), [delete](https://sqlite.org/lang_delete.html)
- transaction with: [begin, savepoint, release, rollback, commit, end](https://sqlite.org/lang_transaction.html)

## Example

```rs
use sql_query_builder as sql;

let update_orders = sql::Update::new()
  .update("orders")
  .set("items = $1")
  .where_clause("login = $2");

let insert_address = sql::Insert::new()
  .insert_into("address(login, contry, postcard)")
  .values("($2, 'Bar', '01234000')");

let query = sql::Transaction::new()
  .begin("")
  .update(update_orders)
  .insert(insert_address)
  .end("")
  .to_string();
  
println!("{query}");
```

```sql
-- indented for readability
BEGIN;
UPDATE orders SET items = $1 WHERE login = $2;
INSERT INTO address(login, contry, postcard) VALUES ($2, 'BR', '01234000');
END;
```