### PR TITLE
Changes the where clause behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ let mut select = sql::Select::new()
 let is_admin = true;
 
 if is_admin {
-  select = select.and("is_admin = true");
+  select = select.where_clause("is_admin = true");
 }
 
 let query = select.as_string();
@@ -141,7 +141,7 @@ fn relations(select: sql::Select) -> sql::Select {
 fn conditions(select: sql::Select) -> sql::Select {
   select
     .where_clause("u.login = $1")
-    .and("o.id = $2")
+    .where_clause("o.id = $2")
 }
 
 fn as_string(select: sql::Select) -> String {

--- a/src/insert/insert.rs
+++ b/src/insert/insert.rs
@@ -277,19 +277,19 @@ impl Insert {
   /// ```
   /// # use sql_query_builder as sql;
   /// let query = sql::Insert::new()
-  ///   .insert_into("users (login)")
+  ///   .insert_into("users (login, name)")
   ///   .values("('foo', 'Foo')")
   ///   .values("('bar', 'Bar')")
   ///   .as_string();
   ///
-  /// # let expected = "INSERT INTO users (login) VALUES ('foo', 'Foo'), ('bar', 'Bar')";
+  /// # let expected = "INSERT INTO users (login, name) VALUES ('foo', 'Foo'), ('bar', 'Bar')";
   /// # assert_eq!(query, expected);
   /// ```
   ///
   /// Output
   ///
   /// ```sql
-  /// INSERT INTO users (login) VALUES ('foo', 'Foo'), ('bar', 'Bar')
+  /// INSERT INTO users (login, name) VALUES ('foo', 'Foo'), ('bar', 'Bar')
   /// ```
   pub fn values(mut self, value: &str) -> Self {
     push_unique(&mut self._values, value.trim().to_owned());

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -11,6 +11,12 @@ pub enum Combinator {
   Union,
 }
 
+#[derive(Clone, PartialEq)]
+pub enum LogicalOperator {
+  And,
+  Or,
+}
+
 /// Builder to contruct a [Delete] command
 #[derive(Default, Clone)]
 pub struct Delete {
@@ -18,7 +24,7 @@ pub struct Delete {
   pub(crate) _raw_after: Vec<(DeleteClause, String)>,
   pub(crate) _raw_before: Vec<(DeleteClause, String)>,
   pub(crate) _raw: Vec<String>,
-  pub(crate) _where: Vec<String>,
+  pub(crate) _where: Vec<(LogicalOperator, String)>,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _returning: Vec<String>,
@@ -127,7 +133,7 @@ pub struct Select {
   pub(crate) _raw_before: Vec<(SelectClause, String)>,
   pub(crate) _raw: Vec<String>,
   pub(crate) _select: Vec<String>,
-  pub(crate) _where: Vec<String>,
+  pub(crate) _where: Vec<(LogicalOperator, String)>,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _except: Vec<Self>,
@@ -223,7 +229,7 @@ pub struct Update {
   pub(crate) _raw_before: Vec<(UpdateClause, String)>,
   pub(crate) _raw: Vec<String>,
   pub(crate) _set: Vec<String>,
-  pub(crate) _where: Vec<String>,
+  pub(crate) _where: Vec<(LogicalOperator, String)>,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _from: Vec<String>,

--- a/tests/command_delete_spec.rs
+++ b/tests/command_delete_spec.rs
@@ -109,6 +109,21 @@ mod builder_features {
 
     assert_eq!(query, expected_query);
   }
+
+  #[test]
+  fn all_standard_clauses_concatenated_in_order() {
+    let query = sql::Delete::new()
+      .delete_from("users")
+      .where_clause("users.login = $1")
+      .as_string();
+
+    let expected_query = "\
+      DELETE FROM users \
+      WHERE users.login = $1\
+    ";
+
+    assert_eq!(query, expected_query);
+  }
 }
 
 mod builder_methods {

--- a/tests/command_insert_spec.rs
+++ b/tests/command_insert_spec.rs
@@ -106,6 +106,24 @@ mod builder_features {
 
     assert_eq!(query, expected_query);
   }
+
+  #[cfg(not(feature = "sqlite"))]
+  #[test]
+  fn all_standard_clauses_concatenated_in_order() {
+    let query = sql::Insert::new()
+      .insert_into("users (login, name)")
+      .overriding("user value")
+      .values("('foo', 'Foo')")
+      .as_string();
+
+    let expected_query = "\
+      INSERT INTO users (login, name) \
+      OVERRIDING user value \
+      VALUES ('foo', 'Foo')\
+    ";
+
+    assert_eq!(query, expected_query);
+  }
 }
 
 mod builder_methods {

--- a/tests/command_select_spec.rs
+++ b/tests/command_select_spec.rs
@@ -93,7 +93,7 @@ mod builder_features {
     }
 
     fn conditions(select: sql::Select) -> sql::Select {
-      select.where_clause("u.login = $1").and("o.id = $2")
+      select.where_clause("u.login = $1").where_clause("o.id = $2")
     }
 
     fn as_string(select: sql::Select) -> String {
@@ -119,7 +119,7 @@ mod builder_features {
   }
 
   #[test]
-  fn all_clauses_concatenated_in_order() {
+  fn all_standard_clauses_concatenated_in_order() {
     let query = sql::Select::new()
       .raw("/* all clauses in order */")
       .select("*")

--- a/tests/command_update_spec.rs
+++ b/tests/command_update_spec.rs
@@ -116,6 +116,23 @@ mod builder_features {
 
     assert_eq!(query, expected_query);
   }
+
+  #[test]
+  fn all_standard_clauses_concatenated_in_order() {
+    let query = sql::Update::new()
+      .update("users")
+      .set("users.name = 'Foo'")
+      .where_clause("users.login = $1")
+      .as_string();
+
+    let expected_query = "\
+      UPDATE users \
+      SET users.name = 'Foo' \
+      WHERE users.login = $1\
+    ";
+
+    assert_eq!(query, expected_query);
+  }
 }
 
 mod builder_methods {


### PR DESCRIPTION
## Breaking changes
This PR changes the behavior of the where clause to support the `OR` operator. The alias `builder.and("...")` was removed in favor of the `builder.where_clause("...")`.

### How to migrate
You will have to replace all use of the `builder.and("...")` to `builder.where_clause("...")`

## New features
Was added in the [Select](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Select.html), [Update](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Update.html) and [Delete](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Delete.html) builders the method `builder.where_or("...")` to support concatenations using  the `OR` operator.

```rs
use sql_query_builder as sql;

let query = sql::Select::new()
  .select("*")
  .from("users")
  .where_clause("login = 'joe'")
  .where_or("login = 'max'")
  .as_string();
```

```sql
SELECT *
FROM users
WHERE
  login = 'joe'
  OR login = 'max'
```