### PR TITLE
Makes the default values clause available to standard syntax

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -44,27 +44,6 @@ pub(crate) trait ConcatSqlStandard<Clause: PartialEq> {
     format!("{query}{raw_sql}{space}{lb}")
   }
 
-  fn concat_values(
-    &self,
-    items_raw_before: &Vec<(Clause, String)>,
-    items_raw_after: &Vec<(Clause, String)>,
-    query: String,
-    fmts: &fmt::Formatter,
-    clause: Clause,
-    items: &Vec<String>,
-  ) -> String {
-    let fmt::Formatter { comma, lb, space, .. } = fmts;
-    let sql = if items.is_empty() == false {
-      let sep = format!("{comma}{lb}");
-      let values = items.join(&sep);
-      format!("VALUES{space}{lb}{values}{space}{lb}")
-    } else {
-      "".to_string()
-    };
-
-    concat_raw_before_after(items_raw_before, items_raw_after, query, fmts, clause, sql)
-  }
-
   fn concat_where(
     &self,
     items_raw_before: &Vec<(Clause, String)>,
@@ -223,30 +202,6 @@ pub(crate) trait ConcatSqlite {
         UpdateClause::UpdateOr,
         format!("UPDATE OR{space}{expression}{space}{lb}"),
       ),
-    };
-
-    concat_raw_before_after(items_raw_before, items_raw_after, query, fmts, clause, sql)
-  }
-
-  fn concat_values(
-    &self,
-    items_raw_before: &Vec<(InsertClause, String)>,
-    items_raw_after: &Vec<(InsertClause, String)>,
-    query: String,
-    fmts: &fmt::Formatter,
-    values: &Vec<String>,
-    default_values: &bool,
-  ) -> String {
-    let fmt::Formatter { comma, lb, space, .. } = fmts;
-
-    let (clause, sql) = if *default_values {
-      (InsertClause::DefaultValues, format!("DEFAULT VALUES{space}{lb}"))
-    } else if values.is_empty() == false {
-      let sep = format!("{comma}{lb}");
-      let values = values.join(&sep);
-      (InsertClause::Values, format!("VALUES{space}{lb}{values}{space}{lb}"))
-    } else {
-      (InsertClause::Values, "".to_string())
     };
 
     concat_raw_before_after(items_raw_before, items_raw_after, query, fmts, clause, sql)

--- a/src/insert/insert.rs
+++ b/src/insert/insert.rs
@@ -65,6 +65,31 @@ impl Insert {
     self
   }
 
+  /// The `default values` clause
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # use sql_query_builder as sql;
+  /// let insert_query = sql::Insert::new()
+  ///   .insert_into("users")
+  ///   .default_values()
+  ///   .to_string();
+  ///
+  /// # let expected = "INSERT INTO users DEFAULT VALUES";
+  /// # assert_eq!(insert_query, expected);
+  /// ```
+  ///
+  /// Output
+  ///
+  /// ```sql
+  /// INSERT INTO users DEFAULT VALUES
+  /// ```
+  pub fn default_values(mut self) -> Self {
+    self._default_values = true;
+    self
+  }
+
   /// The `insert into` clause. This method overrides the previous value
   ///
   /// # Example
@@ -381,34 +406,6 @@ impl Insert {
 
 #[cfg(any(doc, feature = "sqlite"))]
 impl Insert {
-  /// The `default values` clause, this method can be used enabling the feature flag `sqlite`
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// # #[cfg(feature = "sqlite")]
-  /// # {
-  /// # use sql_query_builder as sql;
-  /// let insert_query = sql::Insert::new()
-  ///   .insert_into("users")
-  ///   .default_values()
-  ///   .to_string();
-  ///
-  /// # let expected = "INSERT INTO users DEFAULT VALUES";
-  /// # assert_eq!(insert_query, expected);
-  /// # }
-  /// ```
-  ///
-  /// Output
-  ///
-  /// ```sql
-  /// INSERT INTO users DEFAULT VALUES
-  /// ```
-  pub fn default_values(mut self) -> Self {
-    self._default_values = true;
-    self
-  }
-
   /// The `insert into` clause, this method overrides the previous value and can be used enabling the feature flag `sqlite`
   #[cfg(not(doc))]
   pub fn insert_into(mut self, expression: &str) -> Self {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -52,6 +52,7 @@ pub enum DeleteClause {
 /// Builder to contruct a [Insert] command
 #[derive(Default, Clone)]
 pub struct Insert {
+  pub(crate) _default_values: bool,
   pub(crate) _on_conflict: String,
   pub(crate) _overriding: String,
   pub(crate) _raw_after: Vec<(InsertClause, String)>,
@@ -69,9 +70,6 @@ pub struct Insert {
   pub(crate) _insert_into: String,
   #[cfg(feature = "sqlite")]
   pub(crate) _insert: (InsertVars, String),
-
-  #[cfg(feature = "sqlite")]
-  pub(crate) _default_values: bool,
 }
 
 #[cfg(feature = "sqlite")]
@@ -97,6 +95,7 @@ pub(crate) enum InsertVars {
 /// ```
 #[derive(PartialEq, Clone)]
 pub enum InsertClause {
+  DefaultValues,
   InsertInto,
   OnConflict,
   Overriding,
@@ -107,12 +106,11 @@ pub enum InsertClause {
   Returning,
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   With,
-  #[cfg(any(feature = "sqlite"))]
+
+  #[cfg(feature = "sqlite")]
   InsertOr,
-  #[cfg(any(feature = "sqlite"))]
+  #[cfg(feature = "sqlite")]
   ReplaceInto,
-  #[cfg(any(feature = "sqlite"))]
-  DefaultValues,
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/values/values_internal.rs
+++ b/src/values/values_internal.rs
@@ -1,24 +1,40 @@
 use crate::{
-  behavior::{Concat, ConcatSqlStandard},
+  behavior::{concat_raw_before_after, Concat, ConcatSqlStandard},
   fmt,
   structure::{Values, ValuesClause},
 };
 
 impl ConcatSqlStandard<ValuesClause> for Values {}
 
+impl Values {
+  fn concat_values(&self, query: String, fmts: &fmt::Formatter) -> String {
+    let fmt::Formatter { comma, lb, space, .. } = fmts;
+    let sql = if self._values.is_empty() == false {
+      let sep = format!("{comma}{lb}");
+      let values = self._values.join(&sep);
+      format!("VALUES{space}{lb}{values}{space}{lb}")
+    } else {
+      "".to_string()
+    };
+
+    concat_raw_before_after(
+      &self._raw_before,
+      &self._raw_after,
+      query,
+      fmts,
+      ValuesClause::Values,
+      sql,
+    )
+  }
+}
+
 impl Concat for Values {
   fn concat(&self, fmts: &fmt::Formatter) -> String {
     let mut query = "".to_string();
 
     query = self.concat_raw(query, &fmts, &self._raw);
-    query = self.concat_values(
-      &self._raw_before,
-      &self._raw_after,
-      query,
-      &fmts,
-      ValuesClause::Values,
-      &self._values,
-    );
+
+    query = self.concat_values(query, &fmts);
 
     query.trim_end().to_string()
   }

--- a/tests/clause_default_values_spec.rs
+++ b/tests/clause_default_values_spec.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "sqlite")]
 mod insert_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/clause_insert_or_spec.rs
+++ b/tests/clause_insert_or_spec.rs
@@ -25,6 +25,14 @@ mod insert_command {
   }
 
   #[test]
+  fn method_insert_or_should_not_add_clause_when_argument_is_empty() {
+    let query = sql::Insert::new().insert_or("").as_string();
+    let expected_query = "";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_insert_or_should_trim_space_of_the_argument() {
     let query = sql::Insert::new().insert_or("  IGNORE INTO users (name)  ").as_string();
     let expected_query = "INSERT OR IGNORE INTO users (name)";

--- a/tests/clause_replace_into_spec.rs
+++ b/tests/clause_replace_into_spec.rs
@@ -23,6 +23,14 @@ mod insert_command {
   }
 
   #[test]
+  fn method_replace_into_should_not_add_clause_when_argument_is_empty() {
+    let query = sql::Insert::new().replace_into("").as_string();
+    let expected_query = "";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_replace_into_should_trim_space_of_the_argument() {
     let query = sql::Insert::new().replace_into("  users (name)  ").as_string();
     let expected_query = "REPLACE INTO users (name)";

--- a/tests/clause_update_or_spec.rs
+++ b/tests/clause_update_or_spec.rs
@@ -42,6 +42,14 @@ mod update_command {
   }
 
   #[test]
+  fn method_update_or_should_not_add_clause_when_argument_is_empty() {
+    let query = sql::Update::new().update_or("").as_string();
+    let expected_query = "";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_update_or_should_trim_space_of_the_argument() {
     let query = sql::Update::new().update_or("  REPLACE orders  ").as_string();
     let expected_query = "UPDATE OR REPLACE orders";


### PR DESCRIPTION
## New features
The method `default_values()` are now available in the [Insert](https://docs.rs/sql_query_builder/latest/sql_query_builder/struct.Insert.html) builder.

```rs
use sql_query_builder as sql;

let insert_query = sql::Insert::new()
  .insert_into("users")
  .default_values()
  .as_string();
```

Output

```sql
INSERT INTO users DEFAULT VALUES;
```
