### PR TITLE
Fix accumulator methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ description = "Write SQL queries in a simple and composable way"
 documentation = "https://docs.rs/sql_query_builder"
 repository = "https://github.com/belchior/sql_query_builder"
 authors = ["Belchior Oliveira <belchior@outlook.com>"]
-version = "2.4.0"
+version = "2.4.1"
 edition = "2021"
 rust-version = "1.62"
 license = "MIT"
-keywords = ["sql", "query", "postgres", "sqlite"]
+keywords = ["sql", "query", "database", "postgres", "sqlite"]
 
 [features]
 postgresql = []
@@ -20,4 +20,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = ["postgresql", "sqlite"]
 
 [dev-dependencies]
-pretty_assertions = "1.4.0"
+pretty_assertions = "=1.4.0"

--- a/src/alter_table/alter_table_internal.rs
+++ b/src/alter_table/alter_table_internal.rs
@@ -38,6 +38,7 @@ impl AlterTable {
     let actions = self
       ._ordered_actions
       .iter()
+      .filter(|item| item.1.is_empty() == false)
       .map(|item| {
         let AlterTableActionItem(action, content) = item;
         match action {

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -45,7 +45,7 @@ pub(crate) trait ConcatSqlStandard<Clause: PartialEq> {
       return query;
     }
     let fmt::Formatter { lb, space, .. } = fmts;
-    let raw_sql = items.join(space).trim_start().to_string();
+    let raw_sql = items.join(space).trim().to_string();
 
     format!("{query}{raw_sql}{space}{lb}")
   }
@@ -245,8 +245,8 @@ pub(crate) fn concat_raw_before_after<Clause: PartialEq>(
   sql: String,
 ) -> String {
   let fmt::Formatter { space, .. } = fmts;
-  let raw_before = raw_queries(items_before, &clause).join(space);
-  let raw_after = raw_queries(items_after, &clause).join(space);
+  let raw_before = raw_queries(items_before, &clause).join(space).trim().to_string();
+  let raw_after = raw_queries(items_after, &clause).join(space).trim().to_string();
   let space_after = if raw_after.is_empty() == false { space } else { "" };
   let space_before = if raw_before.is_empty() == false { space } else { "" };
 

--- a/src/create_table/create_table_internal.rs
+++ b/src/create_table/create_table_internal.rs
@@ -32,6 +32,7 @@ impl CreateTable {
     let columns = self
       ._column
       .iter()
+      .filter(|column| column.is_empty() == false)
       .map(|column| format!("{lb}{indent}{column}"))
       .collect::<Vec<_>>()
       .join(comma)
@@ -60,6 +61,7 @@ impl CreateTable {
     let constraints = self
       ._constraint
       .iter()
+      .filter(|constraint| constraint.is_empty() == false)
       .map(|constraint| format!("{lb}{indent}CONSTRAINT{space}{constraint}"))
       .collect::<Vec<_>>()
       .join(comma);
@@ -80,6 +82,7 @@ impl CreateTable {
     let foreign_keys = self
       ._foreign_key
       .iter()
+      .filter(|foreign_key| foreign_key.is_empty() == false)
       .map(|foreign_key| format!("{lb}{indent}FOREIGN KEY{foreign_key}"))
       .collect::<Vec<_>>()
       .join(comma);

--- a/src/drop_index/drop_index_internal.rs
+++ b/src/drop_index/drop_index_internal.rs
@@ -10,7 +10,7 @@ impl DropIndex {
   fn concat_drop_index(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
 
-    let sql = if self._drop_index.len() != 0 {
+    let sql = if self._drop_index.is_empty() == false {
       let if_exists = if self._if_exists {
         format!("IF EXISTS{space}")
       } else {
@@ -18,7 +18,13 @@ impl DropIndex {
       };
 
       let index_names = if cfg!(any(feature = "postgresql")) {
-        self._drop_index.join(comma)
+        self
+          ._drop_index
+          .iter()
+          .filter(|item| item.is_empty() == false)
+          .map(|item| item.as_str())
+          .collect::<Vec<_>>()
+          .join(comma)
       } else {
         self._drop_index.last().unwrap().to_string()
       };

--- a/src/drop_table/drop_table_internal.rs
+++ b/src/drop_table/drop_table_internal.rs
@@ -10,7 +10,7 @@ impl DropTable {
   fn concat_drop_table(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
 
-    let sql = if self._drop_table.len() != 0 {
+    let sql = if self._drop_table.is_empty() == false {
       let if_exists = if self._if_exists {
         format!("IF EXISTS{space}")
       } else {
@@ -18,7 +18,13 @@ impl DropTable {
       };
 
       let table_names = if cfg!(any(feature = "postgresql")) {
-        self._drop_table.join(comma)
+        self
+          ._drop_table
+          .iter()
+          .filter(|item| item.is_empty() == false)
+          .map(|item| item.as_str())
+          .collect::<Vec<_>>()
+          .join(comma)
       } else {
         self._drop_table.last().unwrap().to_string()
       };

--- a/src/insert/insert_internal.rs
+++ b/src/insert/insert_internal.rs
@@ -95,7 +95,13 @@ impl Insert {
       (InsertClause::DefaultValues, format!("DEFAULT VALUES{space}{lb}"))
     } else if self._values.is_empty() == false {
       let sep = format!("{comma}{lb}");
-      let values = self._values.join(&sep);
+      let values = self
+        ._values
+        .iter()
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
+        .collect::<Vec<_>>()
+        .join(&sep);
       (InsertClause::Values, format!("VALUES{space}{lb}{values}{space}{lb}"))
     } else {
       (InsertClause::Values, "".to_string())

--- a/src/select/select.rs
+++ b/src/select/select.rs
@@ -168,8 +168,10 @@ impl Select {
   /// ```
   pub fn cross_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("CROSS JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("CROSS JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 
@@ -195,8 +197,10 @@ impl Select {
   /// ```
   pub fn inner_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("INNER JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("INNER JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 
@@ -222,8 +226,10 @@ impl Select {
   /// ```
   pub fn left_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("LEFT JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("LEFT JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 
@@ -249,8 +255,10 @@ impl Select {
   /// ```
   pub fn right_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("RIGHT JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("RIGHT JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 

--- a/src/select/select_internal.rs
+++ b/src/select/select_internal.rs
@@ -168,8 +168,8 @@ impl Select {
       let columns = self
         ._select
         .iter()
-        .filter(|column| column.is_empty() == false)
-        .map(|column| column.as_str())
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
         .collect::<Vec<_>>()
         .join(comma);
       format!("SELECT{space}{columns}{space}{lb}")
@@ -234,8 +234,8 @@ impl Select {
       Combinator::Union => (SelectClause::Union, "UNION", &self._union),
     };
 
-    let raw_before = raw_queries(&self._raw_before, &clause).join(space);
-    let raw_after = raw_queries(&self._raw_after, &clause).join(space);
+    let raw_before = raw_queries(&self._raw_before, &clause).join(space).trim().to_string();
+    let raw_after = raw_queries(&self._raw_after, &clause).join(space).trim().to_string();
 
     let space_before = if raw_before.is_empty() {
       "".to_string()

--- a/src/select/select_internal.rs
+++ b/src/select/select_internal.rs
@@ -71,7 +71,13 @@ impl Select {
   fn concat_group_by(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
     let sql = if self._group_by.is_empty() == false {
-      let columns = self._group_by.join(comma);
+      let columns = self
+        ._group_by
+        .iter()
+        .filter(|column| column.is_empty() == false)
+        .map(|column| column.as_str())
+        .collect::<Vec<_>>()
+        .join(comma);
       format!("GROUP BY{space}{columns}{space}{lb}")
     } else {
       "".to_string()
@@ -90,7 +96,13 @@ impl Select {
   fn concat_having(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { lb, space, .. } = fmts;
     let sql = if self._having.is_empty() == false {
-      let conditions = self._having.join(" AND ");
+      let conditions = self
+        ._having
+        .iter()
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
+        .collect::<Vec<_>>()
+        .join(" AND ");
       format!("HAVING{space}{conditions}{space}{lb}")
     } else {
       "".to_string()
@@ -128,7 +140,13 @@ impl Select {
   fn concat_order_by(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
     let sql = if self._order_by.is_empty() == false {
-      let columns = self._order_by.join(comma);
+      let columns = self
+        ._order_by
+        .iter()
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
+        .collect::<Vec<_>>()
+        .join(comma);
       format!("ORDER BY{space}{columns}{space}{lb}")
     } else {
       "".to_string()
@@ -147,7 +165,13 @@ impl Select {
   fn concat_select(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
     let sql = if self._select.is_empty() == false {
-      let columns = self._select.join(comma);
+      let columns = self
+        ._select
+        .iter()
+        .filter(|column| column.is_empty() == false)
+        .map(|column| column.as_str())
+        .collect::<Vec<_>>()
+        .join(comma);
       format!("SELECT{space}{columns}{space}{lb}")
     } else {
       "".to_string()
@@ -166,7 +190,13 @@ impl Select {
   fn concat_window(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
     let sql = if self._window.is_empty() == false {
-      let columns = self._window.join(comma);
+      let columns = self
+        ._window
+        .iter()
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
+        .collect::<Vec<_>>()
+        .join(comma);
       format!("WINDOW{space}{columns}{space}{lb}")
     } else {
       "".to_string()

--- a/src/transaction/transaction_internal.rs
+++ b/src/transaction/transaction_internal.rs
@@ -100,7 +100,12 @@ impl Transaction {
   fn concat_ordered_commands(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { lb, space, .. } = fmts;
     let sql = self._ordered_commands.iter().fold("".to_string(), |acc, cmd| {
-      format!("{acc}{0};{space}{lb}", cmd.concat(fmts))
+      let inner_cmd = cmd.concat(fmts);
+      if inner_cmd.is_empty() == false {
+        format!("{acc}{inner_cmd};{space}{lb}")
+      } else {
+        acc
+      }
     });
 
     format!("{query}{sql}")

--- a/src/update/update.rs
+++ b/src/update/update.rs
@@ -452,8 +452,10 @@ impl Update {
   /// ```
   pub fn cross_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("CROSS JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("CROSS JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 
@@ -481,8 +483,10 @@ impl Update {
   /// ```
   pub fn inner_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("INNER JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("INNER JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 
@@ -510,8 +514,10 @@ impl Update {
   /// ```
   pub fn left_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("LEFT JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("LEFT JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 
@@ -539,8 +545,10 @@ impl Update {
   /// ```
   pub fn right_join(mut self, table: &str) -> Self {
     let table = table.trim();
-    let table = format!("RIGHT JOIN {table}");
-    push_unique(&mut self._join, table);
+    if table.is_empty() == false {
+      let table = format!("RIGHT JOIN {table}");
+      push_unique(&mut self._join, table);
+    }
     self
   }
 

--- a/src/update/update_internal.rs
+++ b/src/update/update_internal.rs
@@ -17,7 +17,13 @@ impl Update {
   fn concat_set(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
     let sql = if self._set.is_empty() == false {
-      let values = self._set.join(comma);
+      let values = self
+        ._set
+        .iter()
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
+        .collect::<Vec<_>>()
+        .join(comma);
       format!("SET{space}{values}{space}{lb}")
     } else {
       "".to_string()

--- a/src/values/values_internal.rs
+++ b/src/values/values_internal.rs
@@ -11,7 +11,13 @@ impl Values {
     let fmt::Formatter { comma, lb, space, .. } = fmts;
     let sql = if self._values.is_empty() == false {
       let sep = format!("{comma}{lb}");
-      let values = self._values.join(&sep);
+      let values = self
+        ._values
+        .iter()
+        .filter(|item| item.is_empty() == false)
+        .map(|item| item.as_str())
+        .collect::<Vec<_>>()
+        .join(&sep);
       format!("VALUES{space}{lb}{values}{space}{lb}")
     } else {
       "".to_string()

--- a/tests/clause_from_spec.rs
+++ b/tests/clause_from_spec.rs
@@ -19,6 +19,14 @@ mod select_command {
   }
 
   #[test]
+  fn method_from_should_not_accumulate_values_when_table_name_is_empty() {
+    let query = sql::Select::new().from("").from("users").from("").as_string();
+    let expected_query = "FROM users";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_from_should_trim_space_of_the_argument() {
     let query = sql::Select::new().from("  users  ").as_string();
     let expected_query = "FROM users";
@@ -85,6 +93,14 @@ mod update_command {
   fn method_from_should_accumulate_values_on_consecutive_calls() {
     let query = sql::Update::new().from("users").from("addresses").as_string();
     let expected_query = "FROM users, addresses";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
+  fn method_from_should_not_accumulate_values_when_table_name_is_empty() {
+    let query = sql::Update::new().from("").from("users").from("").as_string();
+    let expected_query = "FROM users";
 
     assert_eq!(query, expected_query);
   }

--- a/tests/clause_group_by_spec.rs
+++ b/tests/clause_group_by_spec.rs
@@ -22,6 +22,18 @@ mod select_command {
   }
 
   #[test]
+  fn method_group_by_should_not_accumulate_values_when_column_name_is_empty() {
+    let query = sql::Select::new()
+      .group_by("")
+      .group_by("created_at")
+      .group_by("")
+      .as_string();
+    let expected_query = "GROUP BY created_at";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_group_by_should_trim_space_of_the_argument() {
     let query = sql::Select::new().group_by("  id, login  ").as_string();
     let expected_query = "GROUP BY id, login";

--- a/tests/clause_having_spec.rs
+++ b/tests/clause_having_spec.rs
@@ -22,6 +22,18 @@ mod select_command {
   }
 
   #[test]
+  fn method_having_should_not_accumulate_values_when_condition_is_empty() {
+    let query = sql::Select::new()
+      .having("")
+      .having("allow = true")
+      .having("")
+      .as_string();
+    let expected_query = "HAVING allow = true";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_having_should_trim_space_of_the_argument() {
     let query = sql::Select::new().having("  sum(amount) > 500  ").as_string();
     let expected_query = "HAVING sum(amount) > 500";

--- a/tests/clause_join_spec.rs
+++ b/tests/clause_join_spec.rs
@@ -145,6 +145,18 @@ mod cross_join_clause {
     }
 
     #[test]
+    fn method_cross_join_should_not_accumulate_values_when_table_name_is_empty() {
+      let query = sql::Update::new()
+        .cross_join("")
+        .cross_join("orders")
+        .cross_join("")
+        .as_string();
+      let expected_query = "CROSS JOIN orders";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_cross_join_by_should_trim_space_of_the_argument() {
       let query = sql::Update::new().cross_join("  orders  ").as_string();
       let expected_query = "CROSS JOIN orders";
@@ -258,6 +270,18 @@ mod inner_join_clause {
         INNER JOIN addresses ON users.login = addresses.login \
         INNER JOIN orders ON users.login = orders.login\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_inner_join_should_not_accumulate_values_when_table_expression_is_empty() {
+      let query = sql::Update::new()
+        .inner_join("")
+        .inner_join("orders ON users.login = orders.login")
+        .inner_join("")
+        .as_string();
+      let expected_query = "INNER JOIN orders ON users.login = orders.login";
 
       assert_eq!(query, expected_query);
     }
@@ -384,6 +408,18 @@ mod left_join_clause {
     }
 
     #[test]
+    fn method_left_join_should_not_accumulate_values_when_table_expression_is_empty() {
+      let query = sql::Update::new()
+        .left_join("")
+        .left_join("orders ON users.login = orders.login")
+        .left_join("")
+        .as_string();
+      let expected_query = "LEFT JOIN orders ON users.login = orders.login";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_left_join_by_should_trim_space_of_the_argument() {
       let query = sql::Update::new().left_join("  orders  ").as_string();
       let expected_query = "LEFT JOIN orders";
@@ -500,6 +536,18 @@ mod right_join_clause {
         RIGHT JOIN addresses ON users.login = addresses.login \
         RIGHT JOIN orders ON users.login = orders.login\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_right_join_should_not_accumulate_values_when_table_expression_is_empty() {
+      let query = sql::Update::new()
+        .right_join("")
+        .right_join("orders ON users.login = orders.login")
+        .right_join("")
+        .as_string();
+      let expected_query = "RIGHT JOIN orders ON users.login = orders.login";
 
       assert_eq!(query, expected_query);
     }

--- a/tests/clause_join_spec.rs
+++ b/tests/clause_join_spec.rs
@@ -90,6 +90,18 @@ mod cross_join_clause {
     }
 
     #[test]
+    fn method_cross_join_should_not_accumulate_values_when_table_name_is_empty() {
+      let query = sql::Select::new()
+        .cross_join("")
+        .cross_join("orders")
+        .cross_join("")
+        .as_string();
+      let expected_query = "CROSS JOIN orders";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_cross_join_by_should_trim_space_of_the_argument() {
       let query = sql::Select::new().cross_join("  orders  ").as_string();
       let expected_query = "CROSS JOIN orders";
@@ -210,6 +222,18 @@ mod inner_join_clause {
         INNER JOIN addresses ON users.login = addresses.login \
         INNER JOIN orders ON users.login = orders.login\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_inner_join_should_not_accumulate_values_when_table_expression_is_empty() {
+      let query = sql::Select::new()
+        .inner_join("")
+        .inner_join("orders ON users.login = orders.login")
+        .inner_join("")
+        .as_string();
+      let expected_query = "INNER JOIN orders ON users.login = orders.login";
 
       assert_eq!(query, expected_query);
     }
@@ -348,6 +372,18 @@ mod left_join_clause {
     }
 
     #[test]
+    fn method_left_join_should_not_accumulate_values_when_table_expression_is_empty() {
+      let query = sql::Select::new()
+        .left_join("")
+        .left_join("orders ON users.login = orders.login")
+        .left_join("")
+        .as_string();
+      let expected_query = "LEFT JOIN orders ON users.login = orders.login";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_left_join_by_should_trim_space_of_the_argument() {
       let query = sql::Select::new().left_join("  orders  ").as_string();
       let expected_query = "LEFT JOIN orders";
@@ -476,6 +512,18 @@ mod right_join_clause {
         RIGHT JOIN addresses ON users.login = addresses.login \
         RIGHT JOIN orders ON users.login = orders.login\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_right_join_should_not_accumulate_values_when_table_expression_is_empty() {
+      let query = sql::Select::new()
+        .right_join("")
+        .right_join("orders ON users.login = orders.login")
+        .right_join("")
+        .as_string();
+      let expected_query = "RIGHT JOIN orders ON users.login = orders.login";
 
       assert_eq!(query, expected_query);
     }

--- a/tests/clause_order_by_spec.rs
+++ b/tests/clause_order_by_spec.rs
@@ -22,6 +22,18 @@ mod select_command {
   }
 
   #[test]
+  fn method_order_by_should_not_accumulate_values_when_column_name_is_empty() {
+    let query = sql::Select::new()
+      .order_by("")
+      .order_by("created_at desc")
+      .order_by("")
+      .as_string();
+    let expected_query = "ORDER BY created_at desc";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_order_by_should_trim_space_of_the_argument() {
     let query = sql::Select::new().order_by("  id desc  ").as_string();
     let expected_query = "ORDER BY id desc";

--- a/tests/clause_returning_spec.rs
+++ b/tests/clause_returning_spec.rs
@@ -20,6 +20,18 @@ mod delete_command {
   }
 
   #[test]
+  fn method_returning_should_not_accumulate_values_when_column_name_is_empty() {
+    let query = sql::Delete::new()
+      .returning("")
+      .returning("name")
+      .returning("")
+      .as_string();
+    let expected_query = "RETURNING name";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_returning_should_not_accumulate_arguments_with_the_same_content() {
     let query = sql::Delete::new().returning("id").returning("id").as_string();
     let expected_query = "RETURNING id";

--- a/tests/clause_select_spec.rs
+++ b/tests/clause_select_spec.rs
@@ -86,9 +86,13 @@ mod select_command {
   }
 
   #[test]
-  fn method_select_should_accumulate_values_on_consecutive_calls() {
-    let query = sql::Select::new().select("id, login").select("created_at").as_string();
-    let expected_query = "SELECT id, login, created_at";
+  fn method_select_should_not_accumulate_values_when_column_name_is_empty() {
+    let query = sql::Select::new()
+      .select("")
+      .select("created_at")
+      .select("")
+      .as_string();
+    let expected_query = "SELECT created_at";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/clause_select_spec.rs
+++ b/tests/clause_select_spec.rs
@@ -86,6 +86,14 @@ mod select_command {
   }
 
   #[test]
+  fn method_select_should_accumulate_values_on_consecutive_calls() {
+    let query = sql::Select::new().select("id, login").select("created_at").as_string();
+    let expected_query = "SELECT id, login, created_at";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_select_should_not_accumulate_values_when_column_name_is_empty() {
     let query = sql::Select::new()
       .select("")

--- a/tests/clause_set_spec.rs
+++ b/tests/clause_set_spec.rs
@@ -19,6 +19,14 @@ mod update_command {
   }
 
   #[test]
+  fn method_set_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Update::new().set("").set("name = 'Foo'").set("").as_string();
+    let expected_query = "SET name = 'Foo'";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_set_should_trim_space_of_the_argument() {
     let query = sql::Update::new().set("  name = 'Bar'  ").as_string();
     let expected_query = "SET name = 'Bar'";

--- a/tests/clause_values_spec.rs
+++ b/tests/clause_values_spec.rs
@@ -22,6 +22,18 @@ mod insert_command {
   }
 
   #[test]
+  fn method_values_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Insert::new()
+      .values("")
+      .values("('bar', 'Bar')")
+      .values("")
+      .as_string();
+    let expected_query = "VALUES ('bar', 'Bar')";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_values_should_trim_space_of_the_argument() {
     let query = sql::Insert::new().values("   ('Bar')  ").as_string();
     let expected_query = "VALUES ('Bar')";

--- a/tests/clause_values_spec.rs
+++ b/tests/clause_values_spec.rs
@@ -110,6 +110,18 @@ mod values_command {
   }
 
   #[test]
+  fn method_values_should_not_accumulate_values_when_table_name_is_empty() {
+    let query = sql::Values::new()
+      .values("")
+      .values("('foo', 'Foo')")
+      .values("")
+      .as_string();
+    let expected_query = "VALUES ('foo', 'Foo')";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_values_should_trim_space_of_the_argument() {
     let query = sql::Values::new().values("   ('Bar')  ").as_string();
     let expected_query = "VALUES ('Bar')";

--- a/tests/clause_where_spec.rs
+++ b/tests/clause_where_spec.rs
@@ -37,6 +37,19 @@ mod where_clause {
     }
 
     #[test]
+    fn method_where_clause_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::CreateIndex::new()
+        .where_clause("")
+        .where_clause("status = 'active'")
+        .where_clause("")
+        .as_string();
+
+      let expected_query = "WHERE status = 'active'";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_where_clause_should_not_accumulate_arguments_with_the_same_content() {
       let query = sql::CreateIndex::new()
         .where_clause("status = 'active'")
@@ -112,6 +125,19 @@ mod where_clause {
           id = $1 \
           AND status = 'pending'\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_where_clause_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::Delete::new()
+        .where_clause("")
+        .where_clause("status = 'pending'")
+        .where_clause("")
+        .as_string();
+
+      let expected_query = "WHERE status = 'pending'";
 
       assert_eq!(query, expected_query);
     }
@@ -208,6 +234,19 @@ mod where_clause {
     }
 
     #[test]
+    fn method_where_clause_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::Select::new()
+        .where_clause("")
+        .where_clause("created_at::date <= current_date")
+        .where_clause("")
+        .as_string();
+
+      let expected_query = "WHERE created_at::date <= current_date";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_where_clause_should_trim_space_of_the_argument() {
       let query = sql::Select::new().where_clause("  id = $1  ").as_string();
       let expected_query = "WHERE id = $1";
@@ -284,6 +323,19 @@ mod where_clause {
           id = $1 \
           AND status = 'pending'\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_where_clause_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::Update::new()
+        .where_clause("")
+        .where_clause("status = 'pending'")
+        .where_clause("")
+        .as_string();
+
+      let expected_query = "WHERE status = 'pending'";
 
       assert_eq!(query, expected_query);
     }
@@ -448,6 +500,19 @@ mod where_or {
     }
 
     #[test]
+    fn method_where_or_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::CreateIndex::new()
+        .where_or("")
+        .where_or("status = 'active'")
+        .where_or("")
+        .as_string();
+
+      let expected_query = "WHERE status = 'active'";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_where_or_should_trim_space_of_the_argument() {
       let query = sql::CreateIndex::new().where_or("  status = 'active'  ").as_string();
       let expected_query = "WHERE status = 'active'";
@@ -523,6 +588,19 @@ mod where_or {
           login = 'foo' \
           OR login = 'bar'\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_where_or_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::Delete::new()
+        .where_or("")
+        .where_or("login = 'bar'")
+        .where_or("")
+        .as_string();
+
+      let expected_query = "WHERE login = 'bar'";
 
       assert_eq!(query, expected_query);
     }
@@ -619,6 +697,19 @@ mod where_or {
     }
 
     #[test]
+    fn method_where_or_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::Select::new()
+        .where_or("")
+        .where_or("login = 'bar'")
+        .where_or("")
+        .as_string();
+
+      let expected_query = "WHERE login = 'bar'";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
     fn method_where_or_should_trim_space_of_the_argument() {
       let query = sql::Select::new().where_or("  id = $1  ").as_string();
       let expected_query = "WHERE id = $1";
@@ -705,6 +796,19 @@ mod where_or {
           login = 'foo' \
           OR login = 'bar'\
       ";
+
+      assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn method_where_or_should_not_accumulate_values_when_expression_is_empty() {
+      let query = sql::Update::new()
+        .where_or("")
+        .where_or("login = 'bar'")
+        .where_or("")
+        .as_string();
+
+      let expected_query = "WHERE login = 'bar'";
 
       assert_eq!(query, expected_query);
     }

--- a/tests/clause_window_spec.rs
+++ b/tests/clause_window_spec.rs
@@ -19,6 +19,14 @@ mod select_command {
   }
 
   #[test]
+  fn method_window_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Select::new().window("").window("bar").window("").as_string();
+    let expected_query = "WINDOW bar";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_window_should_trim_space_of_the_argument() {
     let query = sql::Select::new().window("  foo  ").as_string();
     let expected_query = "WINDOW foo";

--- a/tests/clause_with_spec.rs
+++ b/tests/clause_with_spec.rs
@@ -62,6 +62,18 @@ mod delete_command {
   }
 
   #[test]
+  fn method_with_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Delete::new()
+      .with("deleted_products", sql::Delete::new())
+      .with("deleted_users", sql::Delete::new().delete_from("users"))
+      .with("deleted_orders", sql::Delete::new())
+      .as_string();
+    let expected_query = "WITH deleted_users AS (DELETE FROM users)";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_with_should_trim_space_of_the_argument() {
     let query = sql::Delete::new()
       .with("  deleted_users  ", sql::Delete::new().delete_from("users"))
@@ -190,6 +202,18 @@ mod insert_command {
   }
 
   #[test]
+  fn method_with_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Insert::new()
+      .with("inserted_users", sql::Insert::new())
+      .with("inserted_orders", sql::Insert::new().insert_into("orders"))
+      .with("inserted_products", sql::Insert::new())
+      .as_string();
+    let expected_query = "WITH inserted_orders AS (INSERT INTO orders)";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_with_should_trim_space_of_the_argument() {
     let query = sql::Insert::new()
       .with("  inserted_users  ", sql::Insert::new().insert_into("users"))
@@ -303,6 +327,18 @@ mod select_command {
     let expected_query = "\
       WITH user_list AS (SELECT id, login FROM users), user_ids AS (SELECT id FROM user_list)\
     ";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
+  fn method_with_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Select::new()
+      .with("user_list", sql::Select::new())
+      .with("user_ids", sql::Select::new().select("id").from("user_list"))
+      .with("user_list2", sql::Select::new())
+      .as_string();
+    let expected_query = "WITH user_ids AS (SELECT id FROM user_list)";
 
     assert_eq!(query, expected_query);
   }
@@ -426,6 +462,18 @@ mod update_command {
       WITH updated_users AS (UPDATE users), \
            updated_orders AS (UPDATE orders)\
     ";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
+  fn method_with_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Update::new()
+      .with("updated_users", sql::Update::new())
+      .with("updated_orders", sql::Update::new().update("orders"))
+      .with("updated_users2", sql::Update::new())
+      .as_string();
+    let expected_query = "WITH updated_orders AS (UPDATE orders)";
 
     assert_eq!(query, expected_query);
   }

--- a/tests/command_alter_table_spec.rs
+++ b/tests/command_alter_table_spec.rs
@@ -210,6 +210,19 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::AlterTable::new()
+      .raw("")
+      .raw("add column id serial")
+      .raw("")
+      .as_string();
+
+    let expected_query = "add column id serial";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::AlterTable::new()
       .raw("alter table users")
@@ -286,6 +299,19 @@ mod method_add {
   }
 
   #[test]
+  fn method_add_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::AlterTable::new()
+      .add("")
+      .add("COLUMN created_at timestamp not null")
+      .add("")
+      .as_string();
+
+    let expected_query = "ADD COLUMN created_at timestamp not null";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_add_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
       .add("CONSTRAINT age check(age >= 0)")
@@ -346,6 +372,19 @@ mod method_alter {
       ALTER COLUMN login SET not null, \
       ALTER COLUMN created_at SET DEFAULT now()\
     ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_alter_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::AlterTable::new()
+      .alter("")
+      .alter("COLUMN created_at SET DEFAULT now()")
+      .alter("")
+      .as_string();
+
+    let expected_query = "ALTER COLUMN created_at SET DEFAULT now()";
 
     assert_eq!(expected_query, query);
   }
@@ -448,6 +487,19 @@ mod method_drop {
   }
 
   #[test]
+  fn method_drop_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::AlterTable::new()
+      .drop("")
+      .drop("COLUMN login")
+      .drop("")
+      .as_string();
+
+    let expected_query = "DROP COLUMN login";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_drop_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
       .drop("CONSTRAINT age")
@@ -506,6 +558,19 @@ mod method_rename {
       RENAME COLUMN login TO user_login, \
       RENAME COLUMN created TO created_at\
     ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_rename_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::AlterTable::new()
+      .rename("")
+      .rename("COLUMN created TO created_at")
+      .rename("")
+      .as_string();
+
+    let expected_query = "RENAME COLUMN created TO created_at";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_create_index_spec.rs
+++ b/tests/command_create_index_spec.rs
@@ -229,6 +229,20 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateIndex::new()
+      .raw("")
+      .raw("on users")
+      .raw("(name)")
+      .raw("")
+      .as_string();
+
+    let expected_query = "on users (name)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::CreateIndex::new()
       .raw("/* create index command */")
@@ -311,6 +325,19 @@ mod method_column {
     let query = sql::CreateIndex::new().column("login").column("name").as_string();
 
     let expected_query = "(login, name)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_column_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateIndex::new()
+      .column("")
+      .column("login")
+      .column("")
+      .as_string();
+
+    let expected_query = "(login)";
 
     assert_eq!(expected_query, query);
   }
@@ -844,6 +871,19 @@ mod method_include {
     let query = sql::CreateIndex::new().include("login").include("name").as_string();
 
     let expected_query = "INCLUDE (login, name)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_include_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateIndex::new()
+      .include("")
+      .include("login")
+      .include("")
+      .as_string();
+
+    let expected_query = "INCLUDE (login)";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_create_table_spec.rs
+++ b/tests/command_create_table_spec.rs
@@ -215,6 +215,20 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateTable::new()
+      .raw("")
+      .raw("create table local temp users (")
+      .raw("id serial)")
+      .raw("")
+      .as_string();
+
+    let expected_query = "create table local temp users ( id serial)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::CreateTable::new()
       .raw("create table local temp users")
@@ -279,6 +293,19 @@ mod method_column {
       .as_string();
 
     let expected_query = "(login varchar(40) not null, created_at timestamp not null)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_column_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateTable::new()
+      .column("")
+      .column("login varchar(40) not null")
+      .column("")
+      .as_string();
+
+    let expected_query = "(login varchar(40) not null)";
 
     assert_eq!(expected_query, query);
   }
@@ -355,6 +382,19 @@ mod method_constraint {
         CONSTRAINT id users_id_key primary key(id), \
         CONSTRAINT login users_login_key unique(login)\
       )";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_constraint_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateTable::new()
+      .constraint("")
+      .constraint("login users_login_key unique(login)")
+      .constraint("")
+      .as_string();
+
+    let expected_query = "(CONSTRAINT login users_login_key unique(login))";
 
     assert_eq!(expected_query, query);
   }
@@ -499,6 +539,19 @@ mod method_foreign_key {
       FOREIGN KEY(users_id) REFERENCES users(id), \
       FOREIGN KEY(users_login) REFERENCES users(login)\
     )";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_foreign_key_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::CreateTable::new()
+      .foreign_key("")
+      .foreign_key("(users_login) REFERENCES users(login)")
+      .foreign_key("")
+      .as_string();
+
+    let expected_query = "(FOREIGN KEY(users_login) REFERENCES users(login))";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_delete_spec.rs
+++ b/tests/command_delete_spec.rs
@@ -182,6 +182,18 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Delete::new()
+      .raw("")
+      .raw("delete from addresses")
+      .raw("")
+      .as_string();
+    let expected_query = "delete from addresses";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::Delete::new()
       .raw("delete from addresses")

--- a/tests/command_drop_index_spec.rs
+++ b/tests/command_drop_index_spec.rs
@@ -178,6 +178,20 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::DropIndex::new()
+      .raw("")
+      .raw("drop index")
+      .raw("users_name_idx")
+      .raw("")
+      .as_string();
+
+    let expected_query = "drop index users_name_idx";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::DropIndex::new()
       .raw("/* drop index command */")
@@ -384,6 +398,19 @@ mod postgres_feature_flag {
   }
 
   #[test]
+  fn method_drop_index_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::DropIndex::new()
+      .drop_index("")
+      .drop_index("series")
+      .drop_index("")
+      .as_string();
+
+    let expected_query = "DROP INDEX series";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_drop_index_if_exists_should_accumulate_values_on_consecutive_calls() {
     let query = sql::DropIndex::new()
       .drop_index_if_exists("films_title_idx")
@@ -391,6 +418,19 @@ mod postgres_feature_flag {
       .as_string();
 
     let expected_query = "DROP INDEX IF EXISTS films_title_idx, series";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_drop_index_if_exists_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::DropIndex::new()
+      .drop_index_if_exists("")
+      .drop_index_if_exists("series")
+      .drop_index_if_exists("")
+      .as_string();
+
+    let expected_query = "DROP INDEX IF EXISTS series";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_drop_table_spec.rs
+++ b/tests/command_drop_table_spec.rs
@@ -165,6 +165,20 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::DropTable::new()
+      .raw("")
+      .raw("drop table users")
+      .raw("cascade")
+      .raw("")
+      .as_string();
+
+    let expected_query = "drop table users cascade";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::DropTable::new()
       .raw("/* drop table command */")
@@ -365,6 +379,19 @@ mod postgres_feature_flag {
   }
 
   #[test]
+  fn method_drop_table_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::DropTable::new()
+      .drop_table("")
+      .drop_table("series")
+      .drop_table("")
+      .as_string();
+
+    let expected_query = "DROP TABLE series";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
   fn method_drop_table_if_exists_should_accumulate_values_on_consecutive_calls() {
     let query = sql::DropTable::new()
       .drop_table_if_exists("films")
@@ -372,6 +399,19 @@ mod postgres_feature_flag {
       .as_string();
 
     let expected_query = "DROP TABLE IF EXISTS films, series";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_drop_table_if_exists_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::DropTable::new()
+      .drop_table_if_exists("")
+      .drop_table_if_exists("series")
+      .drop_table_if_exists("")
+      .as_string();
+
+    let expected_query = "DROP TABLE IF EXISTS series";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_insert_spec.rs
+++ b/tests/command_insert_spec.rs
@@ -184,6 +184,19 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Insert::new()
+      .raw("")
+      .raw("/* raw statement */")
+      .raw("insert into addresses (state, country)")
+      .raw("")
+      .as_string();
+    let expected_query = "/* raw statement */ insert into addresses (state, country)";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::Insert::new()
       .raw("insert into addresses (state, country)")

--- a/tests/command_select_spec.rs
+++ b/tests/command_select_spec.rs
@@ -221,6 +221,19 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Select::new()
+      .raw("")
+      .raw("select id")
+      .raw("from users")
+      .raw("")
+      .as_string();
+    let expected_query = "select id from users";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::Select::new().raw("select *").from("users").as_string();
     let expected_query = "select * FROM users";

--- a/tests/command_transaction_spec.rs
+++ b/tests/command_transaction_spec.rs
@@ -263,6 +263,14 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new().raw("").raw("/* raw one */").raw("").as_string();
+    let expected_query = "/* raw one */";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     #[cfg(not(feature = "sqlite"))]
     {
@@ -329,6 +337,19 @@ mod alter_table_method {
 
     assert_eq!(expected_query, query);
   }
+
+  #[test]
+  fn method_alter_table_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .alter_table(sql::AlterTable::new())
+      .alter_table(sql::AlterTable::new().alter_table("orders"))
+      .alter_table(sql::AlterTable::new())
+      .as_string();
+
+    let expected_query = "ALTER TABLE orders;";
+
+    assert_eq!(expected_query, query);
+  }
 }
 
 mod create_table_method {
@@ -357,6 +378,19 @@ mod create_table_method {
 
     assert_eq!(expected_query, query);
   }
+
+  #[test]
+  fn method_create_table_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .create_table(sql::CreateTable::new())
+      .create_table(sql::CreateTable::new().create_table("orders"))
+      .create_table(sql::CreateTable::new())
+      .as_string();
+
+    let expected_query = "CREATE TABLE orders;";
+
+    assert_eq!(expected_query, query);
+  }
 }
 
 mod delete_method {
@@ -380,6 +414,18 @@ mod delete_method {
       .delete(sql::Delete::new().delete_from("users"))
       .as_string();
     let expected_query = "DELETE FROM users; DELETE FROM users;";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
+  fn method_delete_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .delete(sql::Delete::new())
+      .delete(sql::Delete::new().delete_from("users"))
+      .delete(sql::Delete::new())
+      .as_string();
+    let expected_query = "DELETE FROM users;";
 
     assert_eq!(query, expected_query);
   }
@@ -412,6 +458,19 @@ mod create_index_method {
 
     assert_eq!(expected_query, query);
   }
+
+  #[test]
+  fn method_create_index_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .create_index(sql::CreateIndex::new())
+      .create_index(sql::CreateIndex::new().create_index("orders_product_name_idx"))
+      .create_index(sql::CreateIndex::new())
+      .as_string();
+
+    let expected_query = "CREATE INDEX orders_product_name_idx;";
+
+    assert_eq!(expected_query, query);
+  }
 }
 
 #[cfg(any(feature = "postgresql", feature = "sqlite"))]
@@ -438,6 +497,19 @@ mod drop_index_method {
       .as_string();
 
     let expected_query = "DROP INDEX users_name_idx; DROP INDEX orders_product_name_idx;";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_drop_index_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .drop_index(sql::DropIndex::new())
+      .drop_index(sql::DropIndex::new().drop_index("orders_product_name_idx"))
+      .drop_index(sql::DropIndex::new())
+      .as_string();
+
+    let expected_query = "DROP INDEX orders_product_name_idx;";
 
     assert_eq!(expected_query, query);
   }
@@ -469,6 +541,19 @@ mod drop_table_method {
 
     assert_eq!(expected_query, query);
   }
+
+  #[test]
+  fn method_drop_table_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .drop_table(sql::DropTable::new())
+      .drop_table(sql::DropTable::new().drop_table("orders"))
+      .drop_table(sql::DropTable::new())
+      .as_string();
+
+    let expected_query = "DROP TABLE orders;";
+
+    assert_eq!(expected_query, query);
+  }
 }
 
 mod insert_method {
@@ -492,6 +577,18 @@ mod insert_method {
       .insert(sql::Insert::new().insert_into("users (login, name)"))
       .as_string();
     let expected_query = "INSERT INTO users (login, name); INSERT INTO users (login, name);";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
+  fn method_insert_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .insert(sql::Insert::new())
+      .insert(sql::Insert::new().insert_into("users (login, name)"))
+      .insert(sql::Insert::new())
+      .as_string();
+    let expected_query = "INSERT INTO users (login, name);";
 
     assert_eq!(query, expected_query);
   }
@@ -687,6 +784,18 @@ mod select_method {
 
     assert_eq!(query, expected_query);
   }
+
+  #[test]
+  fn method_select_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .select(sql::Select::new())
+      .select(sql::Select::new().select("login, name"))
+      .select(sql::Select::new())
+      .as_string();
+    let expected_query = "SELECT login, name;";
+
+    assert_eq!(query, expected_query);
+  }
 }
 
 mod update_method {
@@ -710,6 +819,18 @@ mod update_method {
       .update(sql::Update::new().update("users"))
       .as_string();
     let expected_query = "UPDATE users; UPDATE users;";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
+  fn method_update_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Transaction::new()
+      .update(sql::Update::new())
+      .update(sql::Update::new().update("users"))
+      .update(sql::Update::new())
+      .as_string();
+    let expected_query = "UPDATE users;";
 
     assert_eq!(query, expected_query);
   }

--- a/tests/command_update_spec.rs
+++ b/tests/command_update_spec.rs
@@ -191,6 +191,14 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Update::new().raw("").raw("update addresses").raw("").as_string();
+    let expected_query = "update addresses";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::Update::new()
       .raw("update addresses")

--- a/tests/command_values_spec.rs
+++ b/tests/command_values_spec.rs
@@ -162,6 +162,14 @@ mod builder_methods {
   }
 
   #[test]
+  fn method_raw_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Values::new().raw("").raw("/* raw one */").raw("").as_string();
+    let expected_query = "/* raw one */";
+
+    assert_eq!(query, expected_query);
+  }
+
+  #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
     let query = sql::Values::new()
       .values("(1, 'one')")


### PR DESCRIPTION
Accumulator methods don't remove calls with empty string and produces invalid sql syntax

```rust
use sql_quer_builder as sql;

let query = sql::Select::new()
  .select("")
  .select("login")
  .as_string();
let expected_query = "select login";

assert_eq!(query, expected_query);
````

```shell
failures:

Diff < left / right > :
<SELECT , login
>SELECT login
```