### PR TITLE
Adds MySQL syntax to Select builder

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -25,3 +25,8 @@ jobs:
         with:
           command: test
           args: --features sqlite
+      - uses: actions-rs/cargo@v1
+        name: Test MySQL syntax
+        with:
+          command: test
+          args: --features mysql

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,28 @@ description = "Write SQL queries in a simple and composable way"
 documentation = "https://docs.rs/sql_query_builder"
 repository = "https://github.com/belchior/sql_query_builder"
 authors = ["Belchior Oliveira <belchior@outlook.com>"]
-version = "2.4.1"
+version = "2.5.1"
 edition = "2021"
 rust-version = "1.62"
 license = "MIT"
-keywords = ["sql", "query", "database", "postgres", "sqlite"]
+keywords = ["sql", "query", "postgres", "sqlite", "mysql"]
 
 [features]
+#! SQL Query Builder comes with the following optional features:
+
+## enable Postgres syntax
 postgresql = []
+
+## enable SQLite syntax
 sqlite = []
+
+## enable MySQL syntax
+mysql = []
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-features = ["postgresql", "sqlite"]
+features = ["postgresql", "sqlite", "mysql"]
 
 [dev-dependencies]
 pretty_assertions = "=1.4.0"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ SELECT id, login FROM users WHERE login = $1 AND is_admin = true
 SQL Query Builder comes with the following optional features:
 - `postgresql` enable Postgres syntax
 - `sqlite` enable SQLite syntax
+- `mysql` enable MySQL syntax
 
 You can enable features like
 

--- a/scripts/coverage_test.sh
+++ b/scripts/coverage_test.sh
@@ -16,6 +16,7 @@ clear
 RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET;
 RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features postgresql;
 RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features sqlite;
+RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features mysql;
 
 cargo profdata -- merge -sparse $COVERAGE_TARGET/$PKG_NAME-*.profraw -o $COVERAGE_TARGET/$PKG_NAME.profdata;
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
-test_names=$(git status -s | grep tests/ | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/.rs//' | tr '\n' ' ')
+test_names=$(git status -s | grep tests/ | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')
 
 clear
 cargo test $test_names
 cargo test $test_names --features postgresql
 cargo test $test_names --features sqlite
+cargo test $test_names --features mysql
 
 # run only one test
 # cargo test --features sqlite --test name_of_the_test_file name_of_the_test -- --nocapture --color always

--- a/scripts/watch_doc.sh
+++ b/scripts/watch_doc.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-doc_path=$(realpath ./target/doc/sql_query_builder/index.html)
+doc_path=$(pwd)/target/doc/sql_query_builder/index.html
 c_blue='\033[34;1m'
 c_no='\033[0m'
 

--- a/scripts/watch_test.sh
+++ b/scripts/watch_test.sh
@@ -8,9 +8,9 @@
 # ./scripts/watch_test.sh all        # will enable all feature
 # ./scripts/watch_test.sh postgresql # will enable only the postgresql feature
 
-all_features='postgresql sqlite'
+all_features='postgresql sqlite mysql'
 features=''
-test_names=$(git status -s | grep tests/ | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/.rs//' | tr '\n' ' ')
+test_names=$(git status -s | grep tests/ | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')
 
 case "$@" in
   "")    features="";;

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -11,7 +11,7 @@ pub trait Concat {
 pub trait TransactionQuery: Concat {}
 
 /// Represents all commands that can be used inside the with method
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 pub trait WithQuery: Concat {}
 
 pub(crate) trait ConcatSqlStandard<Clause: PartialEq> {
@@ -80,7 +80,7 @@ pub(crate) trait ConcatSqlStandard<Clause: PartialEq> {
   }
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 pub(crate) trait ConcatCommon<Clause: PartialEq> {
   fn concat_returning(
     &self,

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -62,6 +62,7 @@ pub fn colorize(query: String) -> String {
     (blue, "ONLY ", "only "),
     (blue, "ORDER BY", "order by"),
     (blue, "OVERRIDING", "overriding"),
+    (blue, "PARTITION", "partition"),
     (blue, "PRIMARY", "primary"),
     (blue, "READ ONLY", "read only"),
     (blue, "READ WRITE", "read write"),

--- a/src/select/select.rs
+++ b/src/select/select.rs
@@ -563,22 +563,23 @@ impl Select {
   }
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 use crate::behavior::WithQuery;
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 impl WithQuery for Select {}
 
-#[cfg(any(doc, feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(doc, feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
 impl Select {
   /// The `except` clause
   ///
   /// # Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let select_users = sql::Select::new()
@@ -618,7 +619,7 @@ impl Select {
   /// # Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let select_users = sql::Select::new()
@@ -658,7 +659,7 @@ impl Select {
   /// # Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let select = sql::Select::new()
@@ -682,7 +683,7 @@ impl Select {
   /// # Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let select = sql::Select::new()
@@ -706,7 +707,7 @@ impl Select {
   /// # Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let select_users = sql::Select::new()
@@ -746,7 +747,7 @@ impl Select {
   /// # Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let logins = sql::Select::new()
@@ -790,9 +791,42 @@ impl Select {
   /// WHERE owner_login in (select * from logins)
   /// -- ------------------------------------------------------------------------------
   /// ```
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub fn with(mut self, name: &str, query: impl WithQuery + 'static) -> Self {
     self._with.push((name.trim().to_string(), std::sync::Arc::new(query)));
+    self
+  }
+}
+
+#[cfg(any(doc, feature = "mysql"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
+impl Select {
+  /// The `partition` clause
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # #[cfg(feature = "mysql")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::Select::new()
+  ///   .select("*")
+  ///   .from("employees")
+  ///   .partition("p1")
+  ///   .to_string();
+  ///
+  /// # let expected_query = "SELECT * FROM employees PARTITION (p1)";
+  /// # assert_eq!(expected_query, query);
+  /// # }
+  /// ```
+  ///
+  /// Output
+  ///
+  /// ```sql
+  /// SELECT * FROM employees PARTITION (p1)
+  /// ```
+  pub fn partition(mut self, name: &str) -> Self {
+    push_unique(&mut self._partition, name.trim().to_string());
     self
   }
 }

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1,9 +1,9 @@
 use crate::behavior::TransactionQuery;
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 use crate::behavior::WithQuery;
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 use std::sync::Arc;
 
 /// Builder to contruct a [AlterTable] command.
@@ -74,7 +74,7 @@ pub enum AlterTableAction {
   RenameTo,
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 pub(crate) enum Combinator {
   Except,
   Intersect,
@@ -479,23 +479,26 @@ pub struct Select {
   pub(crate) _where: Vec<(LogicalOperator, String)>,
   pub(crate) _window: Vec<String>,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _except: Vec<Self>,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _intersect: Vec<Self>,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _limit: String,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _offset: String,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _union: Vec<Self>,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _with: Vec<(String, Arc<dyn WithQuery>)>,
+
+  #[cfg(feature = "mysql")]
+  pub(crate) _partition: Vec<String>,
 }
 
 /// All available clauses to be used in [Select::raw_before] and [Select::raw_after] methods on [Select] builder
@@ -512,25 +515,33 @@ pub enum SelectClause {
   Where,
   Window,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   Except,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   Intersect,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   Union,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   With,
+
+  #[cfg(feature = "mysql")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
+  Partition,
 }
 
 /// Builder to contruct a [Transaction] block.

--- a/tests/clause_except_spec.rs
+++ b/tests/clause_except_spec.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod select_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/clause_intersect_spec.rs
+++ b/tests/clause_intersect_spec.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod select_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/clause_limit_spec.rs
+++ b/tests/clause_limit_spec.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod select_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/clause_offset_spec.rs
+++ b/tests/clause_offset_spec.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod select_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/clause_select_spec.rs
+++ b/tests/clause_select_spec.rs
@@ -106,7 +106,7 @@ mod select_command {
   }
 
   #[test]
-  fn method_select_by_should_trim_space_of_the_argument() {
+  fn method_select_should_trim_space_of_the_argument() {
     let query = sql::Select::new().select("  login, name  ").as_string();
     let expected_query = "SELECT login, name";
 

--- a/tests/clause_union_spec.rs
+++ b/tests/clause_union_spec.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod select_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/clause_with_spec.rs
+++ b/tests/clause_with_spec.rs
@@ -280,7 +280,7 @@ mod insert_command {
   }
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod select_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/command_select_spec.rs
+++ b/tests/command_select_spec.rs
@@ -280,3 +280,112 @@ mod builder_methods {
     assert_eq!(query, expected_query);
   }
 }
+
+#[cfg(feature = "mysql")]
+mod partition_method {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn method_partition_should_define_the_partition_clause() {
+    let query = sql::Select::new().partition("p0").as_string();
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_not_defined_the_clause_without_partition_names() {
+    let query = sql::Select::new().partition("").as_string();
+    let expected_query = "";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_accumulate_names_on_consecutive_calls() {
+    let query = sql::Select::new().partition("p0").partition("p1").as_string();
+
+    let expected_query = "PARTITION (p0, p1)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Select::new()
+      .partition("")
+      .partition("p0")
+      .partition("")
+      .as_string();
+
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_not_accumulate_names_with_the_same_content() {
+    let query = sql::Select::new().partition("p0").partition("p0").as_string();
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_trim_space_of_the_argument() {
+    let query = sql::Select::new().partition("  p0  ").as_string();
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_be_defined_after_from_clause() {
+    let query = sql::Select::new().from("employees").partition("p0").as_string();
+    let expected_query = "FROM employees PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_be_defined_after_join_clauses() {
+    let query = sql::Select::new()
+      .from("employees")
+      .inner_join("addresses ON employees.login = addresses.login")
+      .partition("p0")
+      .as_string();
+
+    let expected_query = "\
+      FROM employees \
+      INNER JOIN addresses ON employees.login = addresses.login \
+      PARTITION (p0)\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_after_should_add_raw_sql_after_partition_parameter() {
+    let query = sql::Select::new()
+      .partition("name")
+      .raw_after(sql::SelectClause::Partition, "/* uncommon parameter */")
+      .as_string();
+
+    let expected_query = "PARTITION (name) /* uncommon parameter */";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_before_should_add_raw_sql_before_partition_parameter() {
+    let query = sql::Select::new()
+      .raw_before(sql::SelectClause::Partition, "/* uncommon parameter */")
+      .partition("name")
+      .as_string();
+
+    let expected_query = "/* uncommon parameter */ PARTITION (name)";
+
+    assert_eq!(expected_query, query);
+  }
+}


### PR DESCRIPTION
Adds MySQL syntax to Select builder

```toml
# Cargo.toml

sql_query_builder = { version = "2.5.1", features = ["mysql"] }
```

Basic API

```rust
use sql_query_builder as sql;

let query = sql::Select::new()
  .select("*")
  .from("employees")
  .partition("p1")
  .to_string();

let expected_query = "SELECT * FROM employees PARTITION (p1)";

assert_eq!(expected_query, query);
```