### PR TITLE
Adds Mysql syntax to Update builder

### DIFF
--- a/src/select/select.rs
+++ b/src/select/select.rs
@@ -116,7 +116,7 @@ impl Select {
   ///   .group_by("id");
   ///
   /// # let expected = "GROUP BY id";
-  /// # assert_eq!(select.as_string(), expected);
+  /// # assert_eq!(expected, select.as_string());
   /// ```
   pub fn group_by(mut self, column: &str) -> Self {
     push_unique(&mut self._group_by, column.trim().to_string());
@@ -280,7 +280,7 @@ impl Select {
   ///   .order_by("login asc");
   ///
   /// # let expected = "SELECT name, login ORDER BY login asc";
-  /// # assert_eq!(select.as_string(), expected);
+  /// # assert_eq!(expected, select.as_string());
   /// ```
   pub fn order_by(mut self, column: &str) -> Self {
     push_unique(&mut self._order_by, column.trim().to_string());
@@ -397,7 +397,7 @@ impl Select {
   ///   .select("count(id)");
   ///
   /// # let expected = "SELECT count(id)";
-  /// # assert_eq!(select.as_string(), expected);
+  /// # assert_eq!(expected, select.as_string());
   /// ```
   pub fn select(mut self, column: &str) -> Self {
     push_unique(&mut self._select, column.trim().to_string());
@@ -672,7 +672,7 @@ impl Select {
   ///   .limit("123");
   ///
   /// # let expected = "LIMIT 123";
-  /// # assert_eq!(select.as_string(), expected);
+  /// # assert_eq!(expected, select.as_string());
   /// # }
   /// ```
   pub fn limit(mut self, num: &str) -> Self {
@@ -696,7 +696,7 @@ impl Select {
   ///   .offset("1500");
   ///
   /// # let expected = "OFFSET 1500";
-  /// # assert_eq!(select.as_string(), expected);
+  /// # assert_eq!(expected, select.as_string());
   /// # }
   /// ```
   pub fn offset(mut self, num: &str) -> Self {
@@ -774,7 +774,7 @@ impl Select {
   /// #   FROM orders \
   /// #   WHERE owner_login in (select * from logins)\
   /// # ";
-  /// # assert_eq!(select.as_string(), expected);
+  /// # assert_eq!(expected, select.as_string());
   /// # }
   /// ```
   ///

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -772,6 +772,12 @@ pub struct Update {
 
   #[cfg(feature = "sqlite")]
   pub(crate) _join: Vec<String>,
+
+  #[cfg(feature = "mysql")]
+  pub(crate) _limit: String,
+
+  #[cfg(feature = "mysql")]
+  pub(crate) _order_by: Vec<String>,
 }
 
 #[cfg(feature = "sqlite")]
@@ -811,6 +817,14 @@ pub enum UpdateClause {
   #[cfg(feature = "sqlite")]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
   Join,
+
+  #[cfg(feature = "mysql")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
+  Limit,
+
+  #[cfg(feature = "mysql")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
+  OrderBy,
 }
 
 /// Builder to contruct a [Values] command.

--- a/src/update/update.rs
+++ b/src/update/update.rs
@@ -600,6 +600,53 @@ impl Update {
   }
 }
 
+#[cfg(any(doc, feature = "mysql"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
+impl Update {
+  /// The `limit` clause, this method overrides the previous value
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # #[cfg(feature = "mysql")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let update = sql::Update::new()
+  ///   .limit("123");
+  ///
+  /// let update = sql::Update::new()
+  ///   .limit("1000")
+  ///   .limit("123");
+  ///
+  /// # let expected = "LIMIT 123";
+  /// # assert_eq!(expected, update.as_string());
+  /// # }
+  /// ```
+  pub fn limit(mut self, num: &str) -> Self {
+    self._limit = num.trim().to_string();
+    self
+  }
+
+  /// The `order by` clause
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # #[cfg(feature = "mysql")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let update = sql::Update::new()
+  ///   .order_by("login asc");
+  ///
+  /// # let expected = "ORDER BY login asc";
+  /// # assert_eq!(expected, update.as_string());
+  /// # }
+  /// ```
+  pub fn order_by(mut self, column: &str) -> Self {
+    push_unique(&mut self._order_by, column.trim().to_string());
+    self
+  }
+}
 impl std::fmt::Display for Update {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
     write!(f, "{}", self.as_string())

--- a/src/update/update_internal.rs
+++ b/src/update/update_internal.rs
@@ -82,6 +82,26 @@ impl Concat for Update {
       &self._where,
     );
 
+    #[cfg(feature = "mysql")]
+    {
+      query = self.concat_order_by(
+        &self._raw_before,
+        &self._raw_after,
+        query,
+        &fmts,
+        UpdateClause::OrderBy,
+        &self._order_by,
+      );
+      query = self.concat_limit(
+        &self._raw_before,
+        &self._raw_after,
+        query,
+        &fmts,
+        UpdateClause::Limit,
+        &self._limit,
+      );
+    }
+
     #[cfg(any(feature = "postgresql", feature = "sqlite"))]
     {
       query = self.concat_returning(
@@ -136,3 +156,11 @@ impl Update {
     )
   }
 }
+
+#[cfg(feature = "mysql")]
+use crate::concat::{non_standard::ConcatLimit, sql_standard::ConcatOrderBy};
+
+#[cfg(feature = "mysql")]
+impl ConcatLimit<UpdateClause> for Update {}
+#[cfg(feature = "mysql")]
+impl ConcatOrderBy<UpdateClause> for Update {}

--- a/tests/clause_limit_spec.rs
+++ b/tests/clause_limit_spec.rs
@@ -117,3 +117,63 @@ mod delete_command {
     assert_eq!(expected_query, query);
   }
 }
+
+#[cfg(feature = "mysql")]
+mod update_command {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn method_limit_should_add_the_limit_clause() {
+    let query = sql::Update::new().limit("3").as_string();
+    let expected_query = "LIMIT 3";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_limit_should_override_the_current_value() {
+    let query = sql::Update::new().limit("3").limit("4").as_string();
+    let expected_query = "LIMIT 4";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_limit_should_trim_space_of_the_argument() {
+    let query = sql::Update::new().limit("  50  ").as_string();
+    let expected_query = "LIMIT 50";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn clause_limit_should_be_after_order_by_clause() {
+    let query = sql::Update::new().order_by("created_at desc").limit("42").as_string();
+    let expected_query = "ORDER BY created_at desc LIMIT 42";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_before_should_add_raw_sql_before_limit_clause() {
+    let query = sql::Update::new()
+      .raw_before(sql::UpdateClause::Limit, "order by id")
+      .limit("10")
+      .as_string();
+    let expected_query = "order by id LIMIT 10";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_after_should_add_raw_sql_after_limit_clause() {
+    let query = sql::Update::new()
+      .limit("10")
+      .raw_after(sql::UpdateClause::Limit, "/* uncommon argument */")
+      .as_string();
+    let expected_query = "LIMIT 10 /* uncommon argument */";
+
+    assert_eq!(expected_query, query);
+  }
+}

--- a/tests/clause_order_by_spec.rs
+++ b/tests/clause_order_by_spec.rs
@@ -187,3 +187,97 @@ mod delete_command {
     assert_eq!(expected_query, query);
   }
 }
+
+#[cfg(feature = "mysql")]
+mod update_command {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn method_order_by_should_add_the_order_by_clause() {
+    let query = sql::Update::new().order_by("id asc").as_string();
+    let expected_query = "ORDER BY id asc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_order_by_should_accumulate_values_on_consecutive_calls() {
+    let query = sql::Update::new()
+      .order_by("login asc")
+      .order_by("created_at desc")
+      .as_string();
+    let expected_query = "ORDER BY login asc, created_at desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_order_by_should_not_accumulate_values_when_column_name_is_empty() {
+    let query = sql::Update::new()
+      .order_by("")
+      .order_by("created_at desc")
+      .order_by("")
+      .as_string();
+    let expected_query = "ORDER BY created_at desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_order_by_should_trim_space_of_the_argument() {
+    let query = sql::Update::new().order_by("  id desc  ").as_string();
+    let expected_query = "ORDER BY id desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_order_by_should_not_accumulate_arguments_with_the_same_content() {
+    let query = sql::Update::new().order_by("id desc").order_by("id desc").as_string();
+    let expected_query = "ORDER BY id desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn clause_order_by_should_be_after_where_clause() {
+    let query = sql::Update::new()
+      .where_clause("active = true")
+      .order_by("created_at desc")
+      .as_string();
+    let expected_query = "WHERE active = true ORDER BY created_at desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn clause_order_by_should_be_after_update_clause() {
+    let query = sql::Update::new().update("foo").order_by("created_at desc").as_string();
+    let expected_query = "UPDATE foo ORDER BY created_at desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_before_should_add_raw_sql_before_order_by_clause() {
+    let query = sql::Update::new()
+      .raw_before(sql::UpdateClause::OrderBy, "where user_login = $1")
+      .order_by("id desc")
+      .as_string();
+    let expected_query = "where user_login = $1 ORDER BY id desc";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_after_should_add_raw_sql_after_order_by_clause() {
+    let query = sql::Update::new()
+      .order_by("id desc")
+      .raw_after(sql::UpdateClause::OrderBy, "limit 20")
+      .as_string();
+    let expected_query = "ORDER BY id desc limit 20";
+
+    assert_eq!(expected_query, query);
+  }
+}


### PR DESCRIPTION
Adds MySQL syntax to Update builder

```rust
use sql_query_builder as sql;

let query = sql::Update::new()
  .update("users")
  .set("name = 'Foo Max'")
  .where_clause("login = 'foo'")
  .order_by("name")
  .limit("1")
  .to_string();

let expected = "\
  UPDATE users \
  SET name = 'Foo Max' \
  WHERE login = 'foo' \
  ORDER BY name \
  LIMIT 1\
";

assert_eq!(expected, query);
```

Reference
- https://dev.mysql.com/doc/refman/9.0/en/update.html