### PR TITLE
Fix alter table

### DIFF
--- a/src/alter_table/alter_table.rs
+++ b/src/alter_table/alter_table.rs
@@ -247,8 +247,7 @@ impl AlterTable {
 #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
 impl AlterTable {
-  /// Changes the column names or table constraints.
-  /// Multiples call of this method will build the SQL respecting the order of the calls
+  /// Changes the column name or table constraints, this method overrides the previous value
   ///
   /// ### Example
   ///
@@ -271,13 +270,12 @@ impl AlterTable {
   /// ```sql
   /// ALTER TABLE users RENAME COLUMN address TO city
   /// ```
-  pub fn rename(mut self, rename_exp: &str) -> Self {
-    let action = AlterTableActionItem(AlterTableOrderedAction::Rename, rename_exp.trim().to_string());
-    push_unique(&mut self._ordered_actions, action);
+  pub fn rename(mut self, action: &str) -> Self {
+    self._rename = action.trim().to_string();
     self
   }
 
-  /// Changes the name of the table
+  /// Changes the name of the table, this method overrides the previous value
   ///
   /// ### Example
   ///

--- a/src/alter_table/alter_table.rs
+++ b/src/alter_table/alter_table.rs
@@ -9,8 +9,7 @@ use crate::{
 impl TransactionQuery for AlterTable {}
 
 impl AlterTable {
-  /// Adds columns or table constraints.
-  /// Multiples call of this method will build the SQL respecting the order of the calls
+  /// Adds columns or table constraints, this method overrides the previous value
   ///
   /// ### Example
   ///
@@ -18,21 +17,43 @@ impl AlterTable {
   /// # use sql_query_builder as sql;
   /// let query = sql::AlterTable::new()
   ///   .add("COLUMN age int not null")
-  ///   .add("CONSTRAINT age check(age >= 0)")
   ///   .as_string();
   ///
-  /// # let expected = "\
-  /// #   ADD COLUMN age int not null, \
-  /// #   ADD CONSTRAINT age check(age >= 0)\
-  /// # ";
+  /// # let expected = "ADD COLUMN age int not null";
   /// # assert_eq!(expected, query);
   /// ```
   ///
   /// Outputs
   ///
   /// ```sql
-  /// ADD COLUMN age int not null,
-  /// ADD CONSTRAINT age check(age >= 0)
+  /// ADD COLUMN age int not null
+  /// ```
+  ///
+  ///
+  /// Available on crate feature `postgresql` only.
+  /// Multiples call of this method will build the SQL respecting the order of the calls
+  ///
+  /// ### Example
+  ///
+  /// ```
+  /// # #[cfg(any(feature = "postgresql"))]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::AlterTable::new()
+  ///   .add("COLUMN login varchar not null")
+  ///   .add("CONSTRAINT login_unique unique(login)")
+  ///   .as_string();
+  ///
+  /// # let expected = "ADD COLUMN login varchar not null, ADD CONSTRAINT login_unique unique(login)";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// ADD COLUMN login varchar not null,
+  /// ADD CONSTRAINT login_unique unique(login)
   /// ```
   pub fn add(mut self, add_exp: &str) -> Self {
     let action = AlterTableActionItem(AlterTableOrderedAction::Add, add_exp.trim().to_string());
@@ -102,8 +123,6 @@ impl AlterTable {
   /// let query = sql::AlterTable::new()
   ///   .alter_table("users")
   ///   .add("name varchar(100) not null")
-  ///   .add("login varchar(40) not null")
-  ///   .add("constraint users_login_key unique(login)")
   ///   .debug()
   ///   .as_string();
   /// ```
@@ -113,9 +132,7 @@ impl AlterTable {
   /// ```sql
   /// -- ------------------------------------------------------------------------------
   /// ALTER TABLE users
-  ///   ADD name varchar(100) not null,
-  ///   ADD login varchar(40) not null,
-  ///   ADD constraint users_login_key unique(login)
+  ///   ADD name varchar(100) not null
   /// -- ------------------------------------------------------------------------------
   /// ```
   pub fn debug(self) -> Self {
@@ -124,8 +141,7 @@ impl AlterTable {
     self
   }
 
-  /// Drops columns or table constraints.
-  /// Multiples call of this method will build the SQL respecting the order of the calls
+  /// Drops columns or table constraints, this method overrides the previous value.
   ///
   /// ### Example
   ///
@@ -143,6 +159,31 @@ impl AlterTable {
   ///
   /// ```sql
   /// DROP column login
+  /// ```
+  ///
+  /// Available on crate feature `postgresql` only.
+  /// Multiples call of this method will build the SQL respecting the order of the calls
+  ///
+  /// ### Example
+  ///
+  /// ```
+  /// # #[cfg(any(feature = "postgresql"))]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::AlterTable::new()
+  ///   .drop("column login")
+  ///   .drop("constraint login_unique")
+  ///   .as_string();
+  ///
+  /// # let expected = "DROP column login, DROP constraint login_unique";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// DROP column login, DROP constraint login_unique
   /// ```
   pub fn drop(mut self, drop_exp: &str) -> Self {
     let action = AlterTableActionItem(AlterTableOrderedAction::Drop, drop_exp.trim().to_string());
@@ -163,7 +204,7 @@ impl AlterTable {
     self
   }
 
-  /// Adds at the beginning a raw SQL query. Is useful to create a more complex alter table signature like the example below.
+  /// Adds at the beginning a raw SQL query. Is useful to create a more complex alter table signature.
   ///
   /// ### Example
   ///
@@ -221,21 +262,21 @@ impl AlterTable {
   ///
   /// ```
   /// # use sql_query_builder as sql;
-  /// let raw = "ALTER TABLE users";
+  /// let raw = "/* alter table command */";
   ///
   /// let query = sql::AlterTable::new()
   ///   .raw_before(sql::AlterTableAction::AlterTable, raw)
-  ///   .add("COLUMN id")
+  ///   .alter_table("users")
   ///   .as_string();
   ///
-  /// # let expected = "ALTER TABLE users ADD COLUMN id";
+  /// # let expected = "/* alter table command */ ALTER TABLE users";
   /// # assert_eq!(expected, query);
   /// ```
   ///
   /// Output
   ///
   /// ```sql
-  /// ALTER TABLE users RENAME TO users_old
+  /// /* alter table command */ ALTER TABLE users
   /// ```
   pub fn raw_before(mut self, action: AlterTableAction, raw_sql: &str) -> Self {
     self._raw_before.push((action, raw_sql.trim().to_string()));

--- a/src/alter_table/alter_table_internal.rs
+++ b/src/alter_table/alter_table_internal.rs
@@ -1,7 +1,7 @@
 use crate::{
   concat::{concat_raw_before_after, Concat},
   fmt,
-  structure::{AlterTable, AlterTableAction, AlterTableActionItem, AlterTableOrderedAction},
+  structure::{AlterTable, AlterTableAction, AlterTableOrderedAction},
 };
 
 impl Concat for AlterTable {
@@ -43,32 +43,52 @@ impl AlterTable {
   }
 
   fn concat_ordered_actions(&self, query: String, fmts: &fmt::Formatter) -> String {
-    let fmt::Formatter {
-      comma,
-      lb,
-      indent,
-      space,
-      ..
-    } = fmts;
+    let actions = self._ordered_actions.iter().filter(|item| item.1.is_empty() == false);
 
-    let actions = self
-      ._ordered_actions
-      .iter()
-      .filter(|item| item.1.is_empty() == false)
-      .map(|item| {
-        let AlterTableActionItem(action, content) = item;
-        match action {
-          AlterTableOrderedAction::Add => format!("{lb}{indent}ADD {content}"),
-          AlterTableOrderedAction::Drop => format!("{lb}{indent}DROP {content}"),
-          #[cfg(any(feature = "postgresql"))]
-          AlterTableOrderedAction::Alter => format!("{lb}{indent}ALTER {content}"),
-        }
-      })
-      .collect::<Vec<_>>()
-      .join(comma)
-      .to_string();
+    #[cfg(any(feature = "postgresql"))]
+    {
+      use crate::structure::AlterTableActionItem;
 
-    format!("{query}{actions}{space}")
+      let fmt::Formatter {
+        comma,
+        lb,
+        indent,
+        space,
+        ..
+      } = fmts;
+
+      let sql = actions
+        .map(|item| {
+          let AlterTableActionItem(action, content) = item;
+          match action {
+            AlterTableOrderedAction::Add => format!("{lb}{indent}ADD{space}{content}"),
+            AlterTableOrderedAction::Drop => format!("{lb}{indent}DROP{space}{content}"),
+            #[cfg(any(feature = "postgresql"))]
+            AlterTableOrderedAction::Alter => format!("{lb}{indent}ALTER{space}{content}"),
+          }
+        })
+        .collect::<Vec<_>>()
+        .join(comma)
+        .to_string();
+
+      format!("{query}{sql}{space}")
+    }
+
+    #[cfg(not(any(feature = "postgresql")))]
+    {
+      let fmt::Formatter { lb, space, .. } = fmts;
+
+      if let Some(item) = actions.last() {
+        let (sql, clause) = match item.0 {
+          AlterTableOrderedAction::Add => (format!("ADD{space}{}{space}{lb}", item.1), AlterTableAction::Add),
+          AlterTableOrderedAction::Drop => (format!("DROP{space}{}{space}{lb}", item.1), AlterTableAction::Drop),
+        };
+
+        return concat_raw_before_after(&self._raw_before, &self._raw_after, query, fmts, clause, sql);
+      }
+
+      query
+    }
   }
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
@@ -94,12 +114,11 @@ impl AlterTable {
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   fn concat_rename_to(&self, query: String, fmts: &fmt::Formatter) -> String {
-    let fmt::Formatter { space, comma, .. } = fmts;
+    let fmt::Formatter { lb, space, .. } = fmts;
     let sql = if self._rename_to.is_empty() == false {
       let table_name = &self._rename_to;
-      let space_or_comma = if self._ordered_actions.is_empty() { space } else { comma };
 
-      format!("RENAME TO{space}{table_name}{space_or_comma}")
+      format!("RENAME TO{space}{table_name}{space}{lb}")
     } else {
       "".to_string()
     };

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -44,6 +44,11 @@ pub struct AlterTable {
   pub(crate) _raw_after: Vec<(AlterTableAction, String)>,
   pub(crate) _raw_before: Vec<(AlterTableAction, String)>,
   pub(crate) _raw: Vec<String>,
+
+  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  pub(crate) _rename: String,
+
+  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _rename_to: String,
 }
 
@@ -56,9 +61,6 @@ pub(crate) enum AlterTableOrderedAction {
   Add,
   Drop,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
-  Rename,
-
   #[cfg(any(feature = "postgresql"))]
   Alter,
 }
@@ -67,6 +69,11 @@ pub(crate) enum AlterTableOrderedAction {
 #[derive(PartialEq, Clone)]
 pub enum AlterTableAction {
   AlterTable,
+
+  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  Rename,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -16,26 +16,16 @@ use std::sync::Arc;
 /// let query = sql::AlterTable::new()
 ///   .alter_table("users")
 ///   .add("COLUMN id serial primary key")
-///   .add("COLUMN login varchar(40) not null")
-///   .drop("CONSTRAINT users_login_key")
 ///   .as_string();
 ///
-/// # let expected = "\
-/// #   ALTER TABLE users \
-/// #     ADD COLUMN id serial primary key, \
-/// #     ADD COLUMN login varchar(40) not null, \
-/// #     DROP CONSTRAINT users_login_key\
-/// # ";
+/// # let expected = "ALTER TABLE users ADD COLUMN id serial primary key";
 /// # assert_eq!(expected, query);
 /// ```
 ///
-/// Output (indented for readability)
+/// Output
 ///
 /// ```sql
-/// ALTER TABLE users
-///   ADD COLUMN id serial primary key,
-///   ADD COLUMN login varchar(40) not null,
-///   DROP CONSTRAINT users_login_key
+/// ALTER TABLE users ADD COLUMN id serial primary key
 /// ```
 #[derive(Default, Clone)]
 pub struct AlterTable {
@@ -79,6 +69,12 @@ pub enum AlterTableAction {
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
   RenameTo,
+
+  #[cfg(not(any(feature = "postgresql")))]
+  Add,
+
+  #[cfg(not(any(feature = "postgresql")))]
+  Drop,
 }
 
 #[cfg(any(feature = "postgresql", feature = "sqlite"))]

--- a/tests/command_alter_table_spec.rs
+++ b/tests/command_alter_table_spec.rs
@@ -101,19 +101,15 @@ mod builder_features {
       // start respecting the order of the calls
       .add("COLUMN login varchar(40) not null")
       .alter("COLUMN login TYPE varchar(80)")
-      .rename("COLUMN login TO user_login")
       .drop("COLUMN user_login")
       // end respecting the order of the calls
-      .rename_to("films")
       .alter_table("users")
       .as_string();
 
     let expected_query = "\
       ALTER TABLE users \
-      RENAME TO films, \
       ADD COLUMN login varchar(40) not null, \
       ALTER COLUMN login TYPE varchar(80), \
-      RENAME COLUMN login TO user_login, \
       DROP COLUMN user_login\
     ";
 
@@ -548,55 +544,13 @@ mod method_rename {
   }
 
   #[test]
-  fn method_rename_should_accumulate_rename_actions_on_consecutive_calls() {
+  fn method_rename_should_override_on_consecutive_calls() {
     let query = sql::AlterTable::new()
       .rename("COLUMN login TO user_login")
       .rename("COLUMN created TO created_at")
-      .as_string();
-
-    let expected_query = "\
-      RENAME COLUMN login TO user_login, \
-      RENAME COLUMN created TO created_at\
-    ";
-
-    assert_eq!(expected_query, query);
-  }
-
-  #[test]
-  fn method_rename_should_not_accumulate_values_when_expression_is_empty() {
-    let query = sql::AlterTable::new()
-      .rename("")
-      .rename("COLUMN created TO created_at")
-      .rename("")
       .as_string();
 
     let expected_query = "RENAME COLUMN created TO created_at";
-
-    assert_eq!(expected_query, query);
-  }
-
-  #[test]
-  fn method_rename_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
-    let query = sql::AlterTable::new()
-      .rename("CONSTRAINT age TO birthdate")
-      .rename("COLUMN age TO birthdate")
-      .as_string();
-
-    let expected_query = "\
-      RENAME CONSTRAINT age TO birthdate, \
-      RENAME COLUMN age TO birthdate\
-    ";
-
-    assert_eq!(expected_query, query);
-  }
-
-  #[test]
-  fn method_rename_should_not_accumulate_actions_with_the_same_content() {
-    let query = sql::AlterTable::new()
-      .rename("COLUMN login TO user_login")
-      .rename("COLUMN login TO user_login")
-      .as_string();
-    let expected_query = "RENAME COLUMN login TO user_login";
 
     assert_eq!(expected_query, query);
   }


### PR DESCRIPTION
Fix the behavior of some  methods in AlterTable builder
- Keep the accumulation logic of the alter table methods `add` e `drop` only for postgres
- The method `rename_to` should override previous values on postgres and sqlite

Reference
- https://www.postgresql.org/docs/current/sql-altertable.html
- https://www.sqlite.org/lang_altertable.html