### PR TITLE
Mysql alter table

### DIFF
--- a/scripts/coverage_test.sh
+++ b/scripts/coverage_test.sh
@@ -27,6 +27,7 @@ echo "\n-- ---------------------------------------------------------------------
 echo "-- Testing SQLite syntax"
 echo "-- ------------------------------------------------------------------------------\n"
 RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features sqlite;
+RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features mysql;
 
 echo "\n-- ------------------------------------------------------------------------------"
 echo "-- Testing MySQL syntax"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,6 +17,7 @@ echo "\n-- ---------------------------------------------------------------------
 echo "-- Testing SQLite syntax"
 echo "-- ------------------------------------------------------------------------------\n"
 cargo test $test_names --features sqlite
+cargo test $test_names --features mysql
 
 echo "\n-- ------------------------------------------------------------------------------"
 echo "-- Testing MySQL syntax"

--- a/src/alter_table/alter_table.rs
+++ b/src/alter_table/alter_table.rs
@@ -247,8 +247,7 @@ impl AlterTable {
 #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
 impl AlterTable {
-  /// Changes the column names or table constraints.
-  /// Multiples call of this method will build the SQL respecting the order of the calls
+  /// Changes the column name or table constraints, this method overrides the previous value
   ///
   /// ### Example
   ///
@@ -271,13 +270,12 @@ impl AlterTable {
   /// ```sql
   /// ALTER TABLE users RENAME COLUMN address TO city
   /// ```
-  pub fn rename(mut self, rename_exp: &str) -> Self {
-    let action = AlterTableActionItem(AlterTableOrderedAction::Rename, rename_exp.trim().to_string());
-    push_unique(&mut self._ordered_actions, action);
+  pub fn rename(mut self, action: &str) -> Self {
+    self._rename = action.trim().to_string();
     self
   }
 
-  /// Changes the name of the table
+  /// Changes the name of the table, this method overrides the previous value
   ///
   /// ### Example
   ///

--- a/src/alter_table/alter_table.rs
+++ b/src/alter_table/alter_table.rs
@@ -29,14 +29,13 @@ impl AlterTable {
   /// ADD COLUMN age int not null
   /// ```
   ///
-  ///
-  /// Available on crate feature `postgresql` only.
+  /// ### Available on crate feature `postgresql` and `mysql` only.
   /// Multiples call of this method will build the SQL respecting the order of the calls
   ///
   /// ### Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::AlterTable::new()
@@ -161,13 +160,13 @@ impl AlterTable {
   /// DROP column login
   /// ```
   ///
-  /// Available on crate feature `postgresql` only.
+  /// ### Available on crate feature `postgresql` and `mysql` only.
   /// Multiples call of this method will build the SQL respecting the order of the calls
   ///
   /// ### Example
   ///
   /// ```
-  /// # #[cfg(any(feature = "postgresql"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::AlterTable::new()
@@ -284,16 +283,17 @@ impl AlterTable {
   }
 }
 
-#[cfg(any(doc, feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(doc, feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
 impl AlterTable {
   /// Changes the column name or table constraints, this method overrides the previous value
   ///
   /// ### Example
   ///
   ///```
-  /// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::AlterTable::new()
@@ -311,11 +311,54 @@ impl AlterTable {
   /// ```sql
   /// ALTER TABLE users RENAME COLUMN address TO city
   /// ```
+  ///
+  /// ### Available on crate feature `mysql` only.
+  /// Changes the table name, column name or table constraints,
+  /// multiples call of this method will build the SQL respecting the order of the calls
+  ///
+  /// ### Example
+  ///
+  ///```
+  /// # #[cfg(feature = "mysql")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::AlterTable::new()
+  ///   .alter_table("users")
+  ///   .rename("TO users_old")
+  ///   .rename("COLUMN name TO full_name")
+  ///   .to_string();
+  ///
+  /// # let expected = "ALTER TABLE users RENAME TO users_old, RENAME COLUMN name TO full_name";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// ALTER TABLE users
+  ///   RENAME TO users_old,
+  ///   RENAME COLUMN name TO full_name
+  /// ```
   pub fn rename(mut self, action: &str) -> Self {
-    self._rename = action.trim().to_string();
+    #[cfg(feature = "mysql")]
+    {
+      let action = AlterTableActionItem(AlterTableOrderedAction::Rename, action.trim().to_string());
+      push_unique(&mut self._ordered_actions, action);
+    }
+    #[cfg(not(feature = "mysql"))]
+    {
+      self._rename = action.trim().to_string();
+    }
+
     self
   }
+}
 
+#[cfg(any(doc, feature = "postgresql", feature = "sqlite"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+impl AlterTable {
   /// Changes the name of the table, this method overrides the previous value
   ///
   /// ### Example
@@ -345,8 +388,9 @@ impl AlterTable {
   }
 }
 
-#[cfg(any(doc, feature = "postgresql"))]
+#[cfg(any(doc, feature = "postgresql", feature = "mysql"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
 impl AlterTable {
   /// Alter columns or table constraints.
   /// Multiples call of this method will build the SQL respecting the order of the calls
@@ -354,7 +398,7 @@ impl AlterTable {
   /// ### Example
   ///
   ///```
-  /// # #[cfg(any(feature = "postgresql"))]
+  /// # #[cfg(any(feature = "postgresql", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::AlterTable::new()

--- a/src/alter_table/alter_table.rs
+++ b/src/alter_table/alter_table.rs
@@ -9,8 +9,7 @@ use crate::{
 impl TransactionQuery for AlterTable {}
 
 impl AlterTable {
-  /// Adds columns or table constraints.
-  /// Multiples call of this method will build the SQL respecting the order of the calls
+  /// Adds columns or table constraints, this method overrides the previous value
   ///
   /// ### Example
   ///
@@ -18,21 +17,43 @@ impl AlterTable {
   /// # use sql_query_builder as sql;
   /// let query = sql::AlterTable::new()
   ///   .add("COLUMN age int not null")
-  ///   .add("CONSTRAINT age check(age >= 0)")
   ///   .as_string();
   ///
-  /// # let expected = "\
-  /// #   ADD COLUMN age int not null, \
-  /// #   ADD CONSTRAINT age check(age >= 0)\
-  /// # ";
+  /// # let expected = "ADD COLUMN age int not null";
   /// # assert_eq!(expected, query);
   /// ```
   ///
   /// Outputs
   ///
   /// ```sql
-  /// ADD COLUMN age int not null,
-  /// ADD CONSTRAINT age check(age >= 0)
+  /// ADD COLUMN age int not null
+  /// ```
+  ///
+  ///
+  /// Available on crate feature `postgresql` only.
+  /// Multiples call of this method will build the SQL respecting the order of the calls
+  ///
+  /// ### Example
+  ///
+  /// ```
+  /// # #[cfg(any(feature = "postgresql"))]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::AlterTable::new()
+  ///   .add("COLUMN login varchar not null")
+  ///   .add("CONSTRAINT login_unique unique(login)")
+  ///   .as_string();
+  ///
+  /// # let expected = "ADD COLUMN login varchar not null, ADD CONSTRAINT login_unique unique(login)";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// ADD COLUMN login varchar not null,
+  /// ADD CONSTRAINT login_unique unique(login)
   /// ```
   pub fn add(mut self, add_exp: &str) -> Self {
     let action = AlterTableActionItem(AlterTableOrderedAction::Add, add_exp.trim().to_string());
@@ -102,8 +123,6 @@ impl AlterTable {
   /// let query = sql::AlterTable::new()
   ///   .alter_table("users")
   ///   .add("name varchar(100) not null")
-  ///   .add("login varchar(40) not null")
-  ///   .add("constraint users_login_key unique(login)")
   ///   .debug()
   ///   .as_string();
   /// ```
@@ -113,9 +132,7 @@ impl AlterTable {
   /// ```sql
   /// -- ------------------------------------------------------------------------------
   /// ALTER TABLE users
-  ///   ADD name varchar(100) not null,
-  ///   ADD login varchar(40) not null,
-  ///   ADD constraint users_login_key unique(login)
+  ///   ADD name varchar(100) not null
   /// -- ------------------------------------------------------------------------------
   /// ```
   pub fn debug(self) -> Self {
@@ -124,8 +141,7 @@ impl AlterTable {
     self
   }
 
-  /// Drops columns or table constraints.
-  /// Multiples call of this method will build the SQL respecting the order of the calls
+  /// Drops columns or table constraints, this method overrides the previous value.
   ///
   /// ### Example
   ///
@@ -143,6 +159,31 @@ impl AlterTable {
   ///
   /// ```sql
   /// DROP column login
+  /// ```
+  ///
+  /// Available on crate feature `postgresql` only.
+  /// Multiples call of this method will build the SQL respecting the order of the calls
+  ///
+  /// ### Example
+  ///
+  /// ```
+  /// # #[cfg(any(feature = "postgresql"))]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::AlterTable::new()
+  ///   .drop("column login")
+  ///   .drop("constraint login_unique")
+  ///   .as_string();
+  ///
+  /// # let expected = "DROP column login, DROP constraint login_unique";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// DROP column login, DROP constraint login_unique
   /// ```
   pub fn drop(mut self, drop_exp: &str) -> Self {
     let action = AlterTableActionItem(AlterTableOrderedAction::Drop, drop_exp.trim().to_string());
@@ -163,7 +204,7 @@ impl AlterTable {
     self
   }
 
-  /// Adds at the beginning a raw SQL query. Is useful to create a more complex alter table signature like the example below.
+  /// Adds at the beginning a raw SQL query. Is useful to create a more complex alter table signature.
   ///
   /// ### Example
   ///
@@ -221,21 +262,21 @@ impl AlterTable {
   ///
   /// ```
   /// # use sql_query_builder as sql;
-  /// let raw = "ALTER TABLE users";
+  /// let raw = "/* alter table command */";
   ///
   /// let query = sql::AlterTable::new()
   ///   .raw_before(sql::AlterTableAction::AlterTable, raw)
-  ///   .add("COLUMN id")
+  ///   .alter_table("users")
   ///   .as_string();
   ///
-  /// # let expected = "ALTER TABLE users ADD COLUMN id";
+  /// # let expected = "/* alter table command */ ALTER TABLE users";
   /// # assert_eq!(expected, query);
   /// ```
   ///
   /// Output
   ///
   /// ```sql
-  /// ALTER TABLE users RENAME TO users_old
+  /// /* alter table command */ ALTER TABLE users
   /// ```
   pub fn raw_before(mut self, action: AlterTableAction, raw_sql: &str) -> Self {
     self._raw_before.push((action, raw_sql.trim().to_string()));

--- a/src/alter_table/alter_table_internal.rs
+++ b/src/alter_table/alter_table_internal.rs
@@ -1,7 +1,7 @@
 use crate::{
   concat::{concat_raw_before_after, Concat},
   fmt,
-  structure::{AlterTable, AlterTableAction, AlterTableActionItem, AlterTableOrderedAction},
+  structure::{AlterTable, AlterTableAction, AlterTableOrderedAction},
 };
 
 impl Concat for AlterTable {
@@ -43,32 +43,52 @@ impl AlterTable {
   }
 
   fn concat_ordered_actions(&self, query: String, fmts: &fmt::Formatter) -> String {
-    let fmt::Formatter {
-      comma,
-      lb,
-      indent,
-      space,
-      ..
-    } = fmts;
+    let actions = self._ordered_actions.iter().filter(|item| item.1.is_empty() == false);
 
-    let actions = self
-      ._ordered_actions
-      .iter()
-      .filter(|item| item.1.is_empty() == false)
-      .map(|item| {
-        let AlterTableActionItem(action, content) = item;
-        match action {
-          AlterTableOrderedAction::Add => format!("{lb}{indent}ADD {content}"),
-          AlterTableOrderedAction::Drop => format!("{lb}{indent}DROP {content}"),
-          #[cfg(any(feature = "postgresql"))]
-          AlterTableOrderedAction::Alter => format!("{lb}{indent}ALTER {content}"),
-        }
-      })
-      .collect::<Vec<_>>()
-      .join(comma)
-      .to_string();
+    #[cfg(any(feature = "postgresql"))]
+    {
+      use crate::structure::AlterTableActionItem;
 
-    format!("{query}{actions}{space}")
+      let fmt::Formatter {
+        comma,
+        lb,
+        indent,
+        space,
+        ..
+      } = fmts;
+
+      let sql = actions
+        .map(|item| {
+          let AlterTableActionItem(action, content) = item;
+          match action {
+            AlterTableOrderedAction::Add => format!("{lb}{indent}ADD{space}{content}"),
+            AlterTableOrderedAction::Drop => format!("{lb}{indent}DROP{space}{content}"),
+            #[cfg(any(feature = "postgresql"))]
+            AlterTableOrderedAction::Alter => format!("{lb}{indent}ALTER{space}{content}"),
+          }
+        })
+        .collect::<Vec<_>>()
+        .join(comma)
+        .to_string();
+
+      format!("{query}{sql}{space}")
+    }
+
+    #[cfg(not(any(feature = "postgresql")))]
+    {
+      let fmt::Formatter { lb, space, .. } = fmts;
+
+      if let Some(item) = actions.last() {
+        let (sql, clause) = match item.0 {
+          AlterTableOrderedAction::Add => (format!("ADD{space}{}{space}{lb}", item.1), AlterTableAction::Add),
+          AlterTableOrderedAction::Drop => (format!("DROP{space}{}{space}{lb}", item.1), AlterTableAction::Drop),
+        };
+
+        return concat_raw_before_after(&self._raw_before, &self._raw_after, query, fmts, clause, sql);
+      }
+
+      query
+    }
   }
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
@@ -94,12 +114,11 @@ impl AlterTable {
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   fn concat_rename_to(&self, query: String, fmts: &fmt::Formatter) -> String {
-    let fmt::Formatter { space, comma, .. } = fmts;
+    let fmt::Formatter { lb, space, .. } = fmts;
     let sql = if self._rename_to.is_empty() == false {
       let table_name = &self._rename_to;
-      let space_or_comma = if self._ordered_actions.is_empty() { space } else { comma };
 
-      format!("RENAME TO{space}{table_name}{space_or_comma}")
+      format!("RENAME TO{space}{table_name}{space}{lb}")
     } else {
       "".to_string()
     };

--- a/src/alter_table/alter_table_internal.rs
+++ b/src/alter_table/alter_table_internal.rs
@@ -45,7 +45,7 @@ impl AlterTable {
   fn concat_ordered_actions(&self, query: String, fmts: &fmt::Formatter) -> String {
     let actions = self._ordered_actions.iter().filter(|item| item.1.is_empty() == false);
 
-    #[cfg(any(feature = "postgresql"))]
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
     {
       use crate::structure::AlterTableActionItem;
 
@@ -63,8 +63,9 @@ impl AlterTable {
           match action {
             AlterTableOrderedAction::Add => format!("{lb}{indent}ADD{space}{content}"),
             AlterTableOrderedAction::Drop => format!("{lb}{indent}DROP{space}{content}"),
-            #[cfg(any(feature = "postgresql"))]
             AlterTableOrderedAction::Alter => format!("{lb}{indent}ALTER{space}{content}"),
+            #[cfg(feature = "mysql")]
+            AlterTableOrderedAction::Rename => format!("{lb}{indent}RENAME{space}{content}"),
           }
         })
         .collect::<Vec<_>>()
@@ -74,7 +75,7 @@ impl AlterTable {
       format!("{query}{sql}{space}")
     }
 
-    #[cfg(not(any(feature = "postgresql")))]
+    #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
     {
       let fmt::Formatter { lb, space, .. } = fmts;
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -44,6 +44,11 @@ pub struct AlterTable {
   pub(crate) _raw_after: Vec<(AlterTableAction, String)>,
   pub(crate) _raw_before: Vec<(AlterTableAction, String)>,
   pub(crate) _raw: Vec<String>,
+
+  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  pub(crate) _rename: String,
+
+  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _rename_to: String,
 }
 
@@ -56,9 +61,6 @@ pub(crate) enum AlterTableOrderedAction {
   Add,
   Drop,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
-  Rename,
-
   #[cfg(any(feature = "postgresql"))]
   Alter,
 }
@@ -67,6 +69,11 @@ pub(crate) enum AlterTableOrderedAction {
 #[derive(PartialEq, Clone)]
 pub enum AlterTableAction {
   AlterTable,
+
+  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  Rename,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -51,8 +51,11 @@ pub(crate) enum AlterTableOrderedAction {
   Add,
   Drop,
 
-  #[cfg(any(feature = "postgresql"))]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   Alter,
+
+  #[cfg(feature = "mysql")]
+  Rename,
 }
 
 /// All available params to be used in [AlterTable::raw_before] and [AlterTable::raw_after] methods on [AlterTable] builder

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -16,26 +16,16 @@ use std::sync::Arc;
 /// let query = sql::AlterTable::new()
 ///   .alter_table("users")
 ///   .add("COLUMN id serial primary key")
-///   .add("COLUMN login varchar(40) not null")
-///   .drop("CONSTRAINT users_login_key")
 ///   .as_string();
 ///
-/// # let expected = "\
-/// #   ALTER TABLE users \
-/// #     ADD COLUMN id serial primary key, \
-/// #     ADD COLUMN login varchar(40) not null, \
-/// #     DROP CONSTRAINT users_login_key\
-/// # ";
+/// # let expected = "ALTER TABLE users ADD COLUMN id serial primary key";
 /// # assert_eq!(expected, query);
 /// ```
 ///
-/// Output (indented for readability)
+/// Output
 ///
 /// ```sql
-/// ALTER TABLE users
-///   ADD COLUMN id serial primary key,
-///   ADD COLUMN login varchar(40) not null,
-///   DROP CONSTRAINT users_login_key
+/// ALTER TABLE users ADD COLUMN id serial primary key
 /// ```
 #[derive(Default, Clone)]
 pub struct AlterTable {
@@ -79,6 +69,12 @@ pub enum AlterTableAction {
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
   RenameTo,
+
+  #[cfg(not(any(feature = "postgresql")))]
+  Add,
+
+  #[cfg(not(any(feature = "postgresql")))]
+  Drop,
 }
 
 #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]

--- a/tests/command_alter_table_spec.rs
+++ b/tests/command_alter_table_spec.rs
@@ -82,7 +82,7 @@ mod builder_features {
   }
 
   #[test]
-  #[cfg(any(feature = "postgresql"))]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   fn ordered_actions_should_respect_the_orders_of_the_call() {
     let query = sql::AlterTable::new()
       // start respecting the order of the calls
@@ -273,7 +273,7 @@ mod method_alter_table {
   }
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod method_rename {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;
@@ -287,6 +287,17 @@ mod method_rename {
   }
 
   #[test]
+  fn method_rename_should_trim_space_of_the_argument() {
+    let query = sql::AlterTable::new()
+      .rename("   COLUMN login TO user_login   ")
+      .as_string();
+    let expected_query = "RENAME COLUMN login TO user_login";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(not(feature = "mysql"))]
+  #[test]
   fn method_rename_should_override_on_consecutive_calls() {
     let query = sql::AlterTable::new()
       .rename("COLUMN login TO user_login")
@@ -298,12 +309,60 @@ mod method_rename {
     assert_eq!(expected_query, query);
   }
 
+  #[cfg(feature = "mysql")]
   #[test]
-  fn method_rename_should_trim_space_of_the_argument() {
+  fn method_rename_should_accumulate_rename_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
-      .rename("   COLUMN login TO user_login   ")
+      .rename("TO users_old")
+      .rename("COLUMN name TO full_name")
       .as_string();
-    let expected_query = "RENAME COLUMN login TO user_login";
+
+    let expected_query = "\
+      RENAME TO users_old, \
+      RENAME COLUMN name TO full_name\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "mysql")]
+  #[test]
+  fn method_rename_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::AlterTable::new()
+      .rename("")
+      .rename("COLUMN name TO full_name")
+      .rename("")
+      .as_string();
+
+    let expected_query = "RENAME COLUMN name TO full_name";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "mysql")]
+  #[test]
+  fn method_rename_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
+    let query = sql::AlterTable::new()
+      .rename("TO users_one")
+      .rename("TO users_two")
+      .as_string();
+
+    let expected_query = "\
+      RENAME TO users_one, \
+      RENAME TO users_two\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "mysql")]
+  #[test]
+  fn method_rename_should_not_accumulate_actions_with_the_same_content() {
+    let query = sql::AlterTable::new()
+      .rename("COLUMN street TO street_name")
+      .rename("COLUMN street TO street_name")
+      .as_string();
+    let expected_query = "RENAME COLUMN street TO street_name";
 
     assert_eq!(expected_query, query);
   }
@@ -365,7 +424,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(not(any(feature = "postgresql")))]
+  #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   #[test]
   fn method_add_should_override_the_current_value() {
     let query = sql::AlterTable::new()
@@ -378,7 +437,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(not(any(feature = "postgresql")))]
+  #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   #[test]
   fn method_raw_before_should_add_raw_sql_before_add_action() {
     let query = sql::AlterTable::new()
@@ -390,7 +449,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(not(any(feature = "postgresql")))]
+  #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   #[test]
   fn method_raw_after_should_add_raw_sql_after_add_action() {
     let query = sql::AlterTable::new()
@@ -402,7 +461,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_add_should_accumulate_add_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
@@ -418,7 +477,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_add_should_not_accumulate_values_when_expression_is_empty() {
     let query = sql::AlterTable::new()
@@ -432,7 +491,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_add_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
@@ -448,7 +507,7 @@ mod method_add {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_add_should_not_accumulate_actions_with_the_same_content() {
     let query = sql::AlterTable::new()
@@ -481,7 +540,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(not(any(feature = "postgresql")))]
+  #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   #[test]
   fn method_drop_should_override_the_current_value() {
     let query = sql::AlterTable::new()
@@ -494,7 +553,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(not(any(feature = "postgresql")))]
+  #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   #[test]
   fn method_raw_before_should_add_raw_sql_before_drop_action() {
     let query = sql::AlterTable::new()
@@ -506,7 +565,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(not(any(feature = "postgresql")))]
+  #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   #[test]
   fn method_raw_after_should_add_raw_sql_after_drop_action() {
     let query = sql::AlterTable::new()
@@ -518,7 +577,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_drop_should_accumulate_drop_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
@@ -534,7 +593,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_drop_should_not_accumulate_values_when_expression_is_empty() {
     let query = sql::AlterTable::new()
@@ -548,7 +607,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_drop_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
     let query = sql::AlterTable::new()
@@ -564,7 +623,7 @@ mod method_drop {
     assert_eq!(expected_query, query);
   }
 
-  #[cfg(feature = "postgresql")]
+  #[cfg(any(feature = "postgresql", feature = "mysql"))]
   #[test]
   fn method_drop_should_not_accumulate_actions_with_the_same_content() {
     let query = sql::AlterTable::new()
@@ -577,7 +636,7 @@ mod method_drop {
   }
 }
 
-#[cfg(any(feature = "postgresql"))]
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
 mod method_alter {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;

--- a/tests/command_alter_table_spec.rs
+++ b/tests/command_alter_table_spec.rs
@@ -101,19 +101,15 @@ mod builder_features {
       // start respecting the order of the calls
       .add("COLUMN login varchar(40) not null")
       .alter("COLUMN login TYPE varchar(80)")
-      .rename("COLUMN login TO user_login")
       .drop("COLUMN user_login")
       // end respecting the order of the calls
-      .rename_to("films")
       .alter_table("users")
       .as_string();
 
     let expected_query = "\
       ALTER TABLE users \
-      RENAME TO films, \
       ADD COLUMN login varchar(40) not null, \
       ALTER COLUMN login TYPE varchar(80), \
-      RENAME COLUMN login TO user_login, \
       DROP COLUMN user_login\
     ";
 
@@ -548,55 +544,13 @@ mod method_rename {
   }
 
   #[test]
-  fn method_rename_should_accumulate_rename_actions_on_consecutive_calls() {
+  fn method_rename_should_override_on_consecutive_calls() {
     let query = sql::AlterTable::new()
       .rename("COLUMN login TO user_login")
       .rename("COLUMN created TO created_at")
-      .as_string();
-
-    let expected_query = "\
-      RENAME COLUMN login TO user_login, \
-      RENAME COLUMN created TO created_at\
-    ";
-
-    assert_eq!(expected_query, query);
-  }
-
-  #[test]
-  fn method_rename_should_not_accumulate_values_when_expression_is_empty() {
-    let query = sql::AlterTable::new()
-      .rename("")
-      .rename("COLUMN created TO created_at")
-      .rename("")
       .as_string();
 
     let expected_query = "RENAME COLUMN created TO created_at";
-
-    assert_eq!(expected_query, query);
-  }
-
-  #[test]
-  fn method_rename_should_preserve_the_order_of_the_actions_on_consecutive_calls() {
-    let query = sql::AlterTable::new()
-      .rename("CONSTRAINT age TO birthdate")
-      .rename("COLUMN age TO birthdate")
-      .as_string();
-
-    let expected_query = "\
-      RENAME CONSTRAINT age TO birthdate, \
-      RENAME COLUMN age TO birthdate\
-    ";
-
-    assert_eq!(expected_query, query);
-  }
-
-  #[test]
-  fn method_rename_should_not_accumulate_actions_with_the_same_content() {
-    let query = sql::AlterTable::new()
-      .rename("COLUMN login TO user_login")
-      .rename("COLUMN login TO user_login")
-      .as_string();
-    let expected_query = "RENAME COLUMN login TO user_login";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_select_spec.rs
+++ b/tests/command_select_spec.rs
@@ -280,3 +280,112 @@ mod builder_methods {
     assert_eq!(query, expected_query);
   }
 }
+
+#[cfg(feature = "mysql")]
+mod partition_method {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn method_partition_should_define_the_partition_clause() {
+    let query = sql::Select::new().partition("p0").as_string();
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_not_defined_the_clause_without_partition_names() {
+    let query = sql::Select::new().partition("").as_string();
+    let expected_query = "";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_accumulate_names_on_consecutive_calls() {
+    let query = sql::Select::new().partition("p0").partition("p1").as_string();
+
+    let expected_query = "PARTITION (p0, p1)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_not_accumulate_values_when_expression_is_empty() {
+    let query = sql::Select::new()
+      .partition("")
+      .partition("p0")
+      .partition("")
+      .as_string();
+
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_not_accumulate_names_with_the_same_content() {
+    let query = sql::Select::new().partition("p0").partition("p0").as_string();
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_trim_space_of_the_argument() {
+    let query = sql::Select::new().partition("  p0  ").as_string();
+    let expected_query = "PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_be_defined_after_from_clause() {
+    let query = sql::Select::new().from("employees").partition("p0").as_string();
+    let expected_query = "FROM employees PARTITION (p0)";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_partition_should_be_defined_after_join_clauses() {
+    let query = sql::Select::new()
+      .from("employees")
+      .inner_join("addresses ON employees.login = addresses.login")
+      .partition("p0")
+      .as_string();
+
+    let expected_query = "\
+      FROM employees \
+      INNER JOIN addresses ON employees.login = addresses.login \
+      PARTITION (p0)\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_after_should_add_raw_sql_after_partition_parameter() {
+    let query = sql::Select::new()
+      .partition("name")
+      .raw_after(sql::SelectClause::Partition, "/* uncommon parameter */")
+      .as_string();
+
+    let expected_query = "PARTITION (name) /* uncommon parameter */";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_before_should_add_raw_sql_before_partition_parameter() {
+    let query = sql::Select::new()
+      .raw_before(sql::SelectClause::Partition, "/* uncommon parameter */")
+      .partition("name")
+      .as_string();
+
+    let expected_query = "/* uncommon parameter */ PARTITION (name)";
+
+    assert_eq!(expected_query, query);
+  }
+}


### PR DESCRIPTION
Basic API

```rust
use sql_query_builder as sql;

let query = sql::AlterTable::new()
  .alter_table("users")
  .add("column id serial primary key")
  .drop("constraint idx_created_at")
  .rename("column name to full_name")
  .as_string();

let expected = "\
  ALTER TABLE users \
  ADD column id serial primary key, \
  DROP constraint idx_created_at, \
  RENAME column name to full_name\
";

assert_eq!(expected, query);
```

Output

```sql
ALTER TABLE users
  ADD COLUMN id serial primary key,
  DROP CONSTRAINT idx_created_at,
  RENAME COLUMN name to full_name
```