### PR TITLE
Adds mysql DropIndex

### DIFF
--- a/src/drop_index/drop_index.rs
+++ b/src/drop_index/drop_index.rs
@@ -38,7 +38,7 @@ impl DropIndex {
   /// ### Example 1
   ///
   ///```
-  /// # #[cfg(not(feature = "postgresql"))]
+  /// # #[cfg(any(feature = "sqlite", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::DropIndex::new()
@@ -82,59 +82,6 @@ impl DropIndex {
   /// ```
   pub fn drop_index(mut self, index_name: &str) -> Self {
     push_unique(&mut self._drop_index, index_name.trim().to_string());
-    self
-  }
-
-  /// Defines a drop index parameter with the `if exists` modifier, this method overrides the previous value
-  ///
-  /// ### Example 1
-  ///
-  /// ```
-  /// # #[cfg(not(feature = "postgresql"))]
-  /// # {
-  /// # use sql_query_builder as sql;
-  /// let query = sql::DropIndex::new()
-  ///   .drop_index("users_name_idx")
-  ///   .drop_index_if_exists("orders_product_name_idx")
-  ///   .to_string();
-  ///
-  /// # let expected = "DROP INDEX IF EXISTS orders_product_name_idx";
-  /// # assert_eq!(expected, query);
-  /// # }
-  /// ```
-  ///
-  /// Outputs
-  ///
-  /// ```sql
-  /// DROP INDEX IF EXISTS orders_product_name_idx
-  /// ```
-  ///
-  /// ### Example 2 `crate features postgresql only`
-  ///
-  /// Multiples call will concatenates all values
-  ///
-  /// ```
-  /// # #[cfg(feature = "postgresql")]
-  /// # {
-  /// # use sql_query_builder as sql;
-  /// let query = sql::DropIndex::new()
-  ///   .drop_index("users_name_idx")
-  ///   .drop_index_if_exists("orders_product_name_idx")
-  ///   .to_string();
-  ///
-  /// # let expected = "DROP INDEX IF EXISTS users_name_idx, orders_product_name_idx";
-  /// # assert_eq!(expected, query);
-  /// # }
-  /// ```
-  ///
-  /// Outputs
-  ///
-  /// ```sql
-  /// DROP INDEX IF EXISTS users_name_idx, orders_product_name_idx
-  /// ```
-  pub fn drop_index_if_exists(mut self, index_name: &str) -> Self {
-    push_unique(&mut self._drop_index, index_name.trim().to_string());
-    self._if_exists = true;
     self
   }
 
@@ -255,6 +202,64 @@ impl DropIndex {
   /// ```
   pub fn raw_before(mut self, param: DropIndexParams, raw_sql: &str) -> Self {
     self._raw_before.push((param, raw_sql.trim().to_string()));
+    self
+  }
+}
+
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+impl DropIndex {
+  /// Defines a drop index parameter with the `if exists` modifier, this method overrides the previous value
+  ///
+  /// ### Example 1
+  ///
+  /// ```
+  /// # #[cfg(feature = "sqlite")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::DropIndex::new()
+  ///   .drop_index("users_name_idx")
+  ///   .drop_index_if_exists("orders_product_name_idx")
+  ///   .to_string();
+  ///
+  /// # let expected = "DROP INDEX IF EXISTS orders_product_name_idx";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// DROP INDEX IF EXISTS orders_product_name_idx
+  /// ```
+  ///
+  /// ### Example 2 `crate features postgresql only`
+  ///
+  /// Multiples call will concatenates all values
+  ///
+  /// ```
+  /// # #[cfg(feature = "postgresql")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::DropIndex::new()
+  ///   .drop_index("users_name_idx")
+  ///   .drop_index_if_exists("orders_product_name_idx")
+  ///   .to_string();
+  ///
+  /// # let expected = "DROP INDEX IF EXISTS users_name_idx, orders_product_name_idx";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Outputs
+  ///
+  /// ```sql
+  /// DROP INDEX IF EXISTS users_name_idx, orders_product_name_idx
+  /// ```
+  pub fn drop_index_if_exists(mut self, index_name: &str) -> Self {
+    push_unique(&mut self._drop_index, index_name.trim().to_string());
+    self._if_exists = true;
     self
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,8 @@ pub use crate::structure::{
 
 #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod create_index;
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod drop_index;
 
 #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
-pub use crate::structure::{CreateIndex, CreateIndexParams};
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
-pub use crate::structure::{DropIndex, DropIndexParams};
+pub use crate::structure::{CreateIndex, CreateIndexParams, DropIndex, DropIndexParams};

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -330,12 +330,12 @@ pub enum DeleteClause {
   Partition,
 }
 
-/// Builder to contruct a [DropIndex] command. Available only for the crate features `postgresql` and `sqlite`.
+/// Builder to contruct a [DropIndex] command. Available only for the crate features `postgresql` and `sqlite` and `mysql`.
 ///
 /// Basic API
 ///
 /// ```
-/// # #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+/// # #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 /// # {
 /// use sql_query_builder as sql;
 ///
@@ -354,7 +354,7 @@ pub enum DeleteClause {
 /// ```sql
 /// DROP INDEX users_name_idx
 /// ```
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 #[derive(Default, Clone)]
 pub struct DropIndex {
   pub(crate) _drop_index: Vec<String>,
@@ -365,7 +365,7 @@ pub struct DropIndex {
 }
 
 /// All available params to be used in [DropIndex::raw_before] and [DropIndex::raw_after] methods on [DropIndex] builder
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 #[derive(PartialEq, Clone)]
 pub enum DropIndexParams {
   DropIndex,


### PR DESCRIPTION
Builder API

```rust
let query = sql::DropIndex::new()
  .drop_index("users_name_idx")
  .as_string();

let expected_query = "DROP INDEX users_name_idx";

assert_eq!(expected_query, query);
```

```sql
DROP INDEX users_name_idx
```

Reference
- https://dev.mysql.com/doc/refman/8.4/en/drop-index.html