### PR TITLE
Adds Mysql syntax to DropTable builder

### DIFF
--- a/src/drop_table/drop_table.rs
+++ b/src/drop_table/drop_table.rs
@@ -38,7 +38,7 @@ impl DropTable {
   /// ### Example 1
   ///
   ///```
-  /// # #[cfg(not(feature = "postgresql"))]
+  /// # #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::DropTable::new()
@@ -57,12 +57,12 @@ impl DropTable {
   /// DROP TABLE orders
   /// ```
   ///
-  /// ### Example 2 `crate features postgresql only`
+  /// ### Example 2 `crate features postgresql and mysql only`
   ///
   /// Multiples call will concatenates all values
   ///
   ///```
-  /// # #[cfg(feature = "postgresql")]
+  /// # #[cfg(any(feature = "postgresql", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::DropTable::new()
@@ -90,7 +90,7 @@ impl DropTable {
   /// ### Example 1
   ///
   /// ```
-  /// # #[cfg(not(feature = "postgresql"))]
+  /// # #[cfg(not(any(feature = "postgresql", feature = "mysql")))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::DropTable::new()
@@ -109,12 +109,12 @@ impl DropTable {
   /// DROP TABLE IF EXISTS orders
   /// ```
   ///
-  /// ### Example 2 `crate features postgresql only`
+  /// ### Example 2 `crate features postgresql and mysql only`
   ///
   /// Multiples call will concatenates all values
   ///
   /// ```
-  /// # #[cfg(feature = "postgresql")]
+  /// # #[cfg(any(feature = "postgresql", feature = "mysql"))]
   /// # {
   /// # use sql_query_builder as sql;
   /// let query = sql::DropTable::new()

--- a/src/drop_table/drop_table_internal.rs
+++ b/src/drop_table/drop_table_internal.rs
@@ -26,7 +26,7 @@ impl DropTable {
         "".to_string()
       };
 
-      let table_names = if cfg!(any(feature = "postgresql")) {
+      let table_names = if cfg!(any(feature = "postgresql", feature = "mysql")) {
         self
           ._drop_table
           .iter()


### PR DESCRIPTION
Builder API

```rust
let query = sql::DropTable::new()
  // at least one of methods
  .drop_table("users_name_idx")
  .drop_table_if_exists("users_login_idx")
  .as_string();

let expected_query = "DROP TABLE IF EXISTS users_name_idx, users_login_idx";

assert_eq!(expected_query, query);
```

Reference
- https://dev.mysql.com/doc/refman/8.4/en/drop-table.html