### PR TITLE
Adds MySQL syntax to Transaction builder

### DIFF
--- a/scripts/coverage_test.sh
+++ b/scripts/coverage_test.sh
@@ -27,7 +27,6 @@ echo "\n-- ---------------------------------------------------------------------
 echo "-- Testing SQLite syntax"
 echo "-- ------------------------------------------------------------------------------\n"
 RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features sqlite;
-RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="$COVERAGE_TARGET/$PKG_NAME-%m.profraw" cargo test --target-dir $COVERAGE_TARGET --features mysql;
 
 echo "\n-- ------------------------------------------------------------------------------"
 echo "-- Testing MySQL syntax"

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -695,7 +695,7 @@ pub enum SelectClause {
 /// # }
 /// ```
 ///
-/// Output (indented for readability)
+/// Output
 ///
 /// ```sql
 /// START TRANSACTION isolation level serializable;
@@ -711,7 +711,7 @@ pub struct Transaction {
   pub(crate) _set_transaction: Option<TransactionCommand>,
   pub(crate) _start_transaction: Option<TransactionCommand>,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   pub(crate) _begin: Option<TransactionCommand>,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
@@ -726,9 +726,10 @@ pub(crate) enum TrCmd {
   Rollback,
   Savepoint,
 
-  #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+  #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
   #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   Begin,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
@@ -738,10 +739,12 @@ pub(crate) enum TrCmd {
 
   #[cfg(not(feature = "sqlite"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   SetTransaction,
 
   #[cfg(not(feature = "sqlite"))]
   #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+  #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
   StartTransaction,
 }
 

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -7,7 +7,7 @@ use crate::{
   utils::push_unique,
 };
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 use crate::structure::{CreateIndex, DropIndex};
 
 impl Transaction {
@@ -46,8 +46,6 @@ impl Transaction {
   /// # Example
   ///
   /// ```
-  /// # #[cfg(not(feature = "sqlite"))]
-  /// # {
   /// # use sql_query_builder as sql;
   /// let transaction_query = sql::Transaction::new()
   ///   .commit("WORK")
@@ -56,7 +54,6 @@ impl Transaction {
   ///
   /// # let expected = "COMMIT TRANSACTION;";
   /// # assert_eq!(transaction_query, expected);
-  /// # }
   /// ```
   ///
   /// Output
@@ -596,9 +593,10 @@ impl Transaction {
   }
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
 impl Transaction {
   /// The `begin` command, this method will be always added at the beginning of the transation and
   /// all consecutive call will override the previous value.
@@ -710,7 +708,12 @@ impl Transaction {
     self._ordered_commands.push(cmd);
     self
   }
+}
 
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "postgresql")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
+impl Transaction {
   /// The `end` command, this method will be always added at the end of the transation and
   /// all consecutive call will override the previous value.
   ///

--- a/src/transaction/transaction_internal.rs
+++ b/src/transaction/transaction_internal.rs
@@ -16,7 +16,7 @@ impl Concat for Transaction {
 
     query = self.concat_raw(query, &fmts, &self._raw);
 
-    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+    #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
     {
       query = self.concat_begin(query, &fmts);
     }
@@ -52,7 +52,7 @@ impl Concat for TransactionCommand {
       Rollback => format!("ROLLBACK{arg}"),
       Savepoint => format!("SAVEPOINT{arg}"),
 
-      #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+      #[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
       Begin => format!("BEGIN{arg}"),
       #[cfg(any(feature = "postgresql", feature = "sqlite"))]
       End => format!("END{arg}"),
@@ -117,7 +117,7 @@ impl TransactionCommand {
   }
 }
 
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 impl Transaction {
   fn concat_begin(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { lb, space, .. } = fmts;
@@ -128,7 +128,10 @@ impl Transaction {
 
     format!("{query}{sql}")
   }
+}
 
+#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+impl Transaction {
   fn concat_end(&self, query: String, fmts: &fmt::Formatter) -> String {
     let fmt::Formatter { lb, space, .. } = fmts;
     let sql = match &self._end {

--- a/tests/command_begin_spec.rs
+++ b/tests/command_begin_spec.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "postgresql", feature = "sqlite"))]
+#[cfg(any(feature = "postgresql", feature = "sqlite", feature = "mysql"))]
 mod begin_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;


### PR DESCRIPTION
Builder API

```rust
use sql_query_builder as sql;

let query = sql::Transaction::new()
  // one of methods
  .begin("")
  .start_transaction("")
  // optional methods
  .set_transaction("")
  // at least one of methods
  .alter_table(sql::AlterTable::new().alter_table("users"))
  .create_index(sql::CreateIndex::new().create_index("users_idx"))
  .create_table(sql::CreateTable::new().create_table("users"))
  .delete(sql::Delete::new().delete_from("users"))
  .drop_index(sql::DropIndex::new().drop_index("users_idx"))
  .drop_table(sql::DropTable::new().drop_table("users"))
  .insert(sql::Insert::new().insert_into("users"))
  .select(sql::Select::new().select("login"))
  .update(sql::Update::new().update("users"))
  // one of methods
  .rollback("")
  .commit("")
  .as_string();

let expected_query = "\
  BEGIN; \
  START TRANSACTION; \
  SET TRANSACTION; \
  ALTER TABLE users; \
  CREATE INDEX users_idx; \
  CREATE TABLE users; \
  DELETE FROM users; \
  DROP INDEX users_idx; \
  DROP TABLE users; \
  INSERT INTO users; \
  SELECT login; \
  UPDATE users; \
  ROLLBACK; \
  COMMIT;\
";

assert_eq!(expected_query, query);
```

Reference
- https://dev.mysql.com/doc/refman/8.4/en/commit.html
- https://dev.mysql.com/doc/refman/8.4/en/savepoint.html