### PR TITLE
Adds MySQL syntax to Values builder

### DIFF
--- a/scripts/coverage_test.sh
+++ b/scripts/coverage_test.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Prerequisites
-# cargo install rustfilt cargo-binutils
+# rustup override set 1.82.0
+# cargo install rustfilt@0.2.1 cargo-binutils@0.3.6
 # rustup component add llvm-tools-preview
 clear
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_names=$(git status -s | grep 'A tests/\|M tests/' | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')
+test_names=$(git status -s | grep 'A[[:space:]]*tests/\|M[[:space:]]*tests/' | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')
 
 clear
 echo "\n-- ------------------------------------------------------------------------------"

--- a/scripts/watch_test.sh
+++ b/scripts/watch_test.sh
@@ -10,7 +10,7 @@
 
 all_features='postgresql sqlite mysql'
 features=''
-test_names=$(git status -s | grep 'A tests/\|M tests/' | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')
+test_names=$(git status -s | grep 'A[[:space:]]*tests/\|M[[:space:]]*tests/' | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')
 
 case "$@" in
   "")    features="";;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -72,6 +72,7 @@ pub fn colorize(query: String) -> String {
     (blue, "RETURNING", "returning"),
     (blue, "RIGHT", "right"),
     (blue, "ROLLBACK", "rollback"),
+    (blue, "ROW", "row"),
     (blue, "SAVEPOINT", "savepoint"),
     (blue, "SELECT ", "select "),
     (blue, "SERIALIZABLE", "serializable"),

--- a/src/insert/insert.rs
+++ b/src/insert/insert.rs
@@ -311,8 +311,8 @@ impl Insert {
   /// ```sql
   /// INSERT INTO users (login, name) VALUES ('foo', 'Foo'), ('bar', 'Bar')
   /// ```
-  pub fn values(mut self, value: &str) -> Self {
-    push_unique(&mut self._values, value.trim().to_string());
+  pub fn values(mut self, expression: &str) -> Self {
+    push_unique(&mut self._values, expression.trim().to_string());
     #[cfg(not(feature = "mysql"))]
     {
       self._default_values = false
@@ -660,6 +660,36 @@ impl Insert {
   /// ```
   pub fn on_duplicate_key_update(mut self, assignment: &str) -> Self {
     push_unique(&mut self._on_duplicate_key_update, assignment.trim().to_string());
+    self
+  }
+
+  /// The `values` clause with the `row` constructor clause
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # #[cfg(feature = "mysql")]
+  /// # {
+  /// # use sql_query_builder as sql;
+  /// let query = sql::Insert::new()
+  ///   .insert_into("users (login, name)")
+  ///   .row("('foo', 'Foo')")
+  ///   .row("('bar', 'Bar')")
+  ///   .as_string();
+  ///
+  /// # let expected = "INSERT INTO users (login, name) VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+  /// # assert_eq!(expected, query);
+  /// # }
+  /// ```
+  ///
+  /// Output
+  ///
+  /// ```sql
+  /// INSERT INTO users (login, name) VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')
+  /// ```
+  pub fn row(mut self, expression: &str) -> Self {
+    push_unique(&mut self._values, expression.trim().to_string());
+    self._use_row = true;
     self
   }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -437,6 +437,7 @@ pub struct Insert {
   pub(crate) _raw: Vec<String>,
   pub(crate) _select: Option<Select>,
   pub(crate) _values: Vec<String>,
+  pub(crate) _use_row: bool,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _on_conflict: String,
@@ -858,6 +859,8 @@ pub enum UpdateClause {
 /// Basic API
 ///
 /// ```
+/// # #[cfg(not(feature = "mysql"))]
+/// # {
 /// use sql_query_builder as sql;
 ///
 /// let query = sql::Values::new()
@@ -867,6 +870,7 @@ pub enum UpdateClause {
 ///
 /// # let expected = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
 /// # assert_eq!(expected, query);
+/// # }
 /// ```
 ///
 /// Output

--- a/src/values/values.rs
+++ b/src/values/values.rs
@@ -17,13 +17,16 @@ impl Values {
   /// # Example
   ///
   /// ```
+  /// # #[cfg(not(feature = "mysql"))]
+  /// # {
   /// # use sql_query_builder as sql;
   /// let values_query = sql::Values::new()
   ///   .values("('foo', 'Foo')")
   ///   .as_string();
   ///
   /// # let expected = "VALUES ('foo', 'Foo')";
-  /// # assert_eq!(values_query, expected);
+  /// # assert_eq!(expected, values_query);
+  /// # }
   /// ```
   ///
   /// Output
@@ -42,6 +45,8 @@ impl Values {
   /// # Example
   ///
   /// ```
+  /// # #[cfg(not(feature = "mysql"))]
+  /// # {
   /// # use sql_query_builder as sql;
   /// let values = sql::Values::new()
   ///   .values("(1, 'one'), (2, 'two')")
@@ -49,7 +54,8 @@ impl Values {
   ///   .debug();
   ///
   /// # let expected = "VALUES (1, 'one'), (2, 'two'), (3, 'three')";
-  /// # assert_eq!(values.as_string(), expected);
+  /// # assert_eq!(expected, values.as_string());
+  /// # }
   /// ```
   ///
   /// Prints to the standard output
@@ -83,6 +89,8 @@ impl Values {
   /// # Example
   ///
   /// ```
+  /// # #[cfg(not(feature = "mysql"))]
+  /// # {
   /// # use sql_query_builder as sql;
   /// let raw_query = "insert into my_table(num, txt)";
   ///
@@ -92,7 +100,8 @@ impl Values {
   ///   .as_string();
   ///
   /// # let expected = "insert into my_table(num, txt) VALUES (1, 'one'), (2, 'two')";
-  /// # assert_eq!(values_query, expected);
+  /// # assert_eq!(expected, values_query);
+  /// # }
   /// ```
   ///
   /// Output
@@ -111,6 +120,8 @@ impl Values {
   /// # Example
   ///
   /// ```
+  /// # #[cfg(not(feature = "mysql"))]
+  /// # {
   /// # use sql_query_builder as sql;
   /// let raw_query = ", (3, 'three')";
   ///
@@ -120,7 +131,8 @@ impl Values {
   ///   .as_string();
   ///
   /// # let expected = "VALUES (1, 'one'), (2, 'two') , (3, 'three')";
-  /// # assert_eq!(values_query, expected);
+  /// # assert_eq!(expected, values_query);
+  /// # }
   /// ```
   ///
   /// Output
@@ -138,6 +150,8 @@ impl Values {
   /// # Example
   ///
   /// ```
+  /// # #[cfg(not(feature = "mysql"))]
+  /// # {
   /// # use sql_query_builder as sql;
   /// let raw_query = "/* the values command */";
   ///
@@ -147,7 +161,8 @@ impl Values {
   ///   .as_string();
   ///
   /// # let expected = "/* the values command */ VALUES (1, 'one'), (2, 'two')";
-  /// # assert_eq!(values_query, expected);
+  /// # assert_eq!(expected, values_query);
+  /// # }
   /// ```
   ///
   /// Output
@@ -166,6 +181,8 @@ impl Values {
   /// # Example
   ///
   /// ```
+  /// # #[cfg(not(feature = "mysql"))]
+  /// # {
   /// # use sql_query_builder as sql;
   /// let values_query = sql::Values::new()
   ///   .values("(1, 'one'), (2, 'two')")
@@ -173,7 +190,8 @@ impl Values {
   ///   .as_string();
   ///
   /// # let expected = "VALUES (1, 'one'), (2, 'two'), (3, 'three')";
-  /// # assert_eq!(values_query, expected);
+  /// # assert_eq!(expected, values_query);
+  /// # }
   /// ```
   ///
   /// Output
@@ -181,7 +199,37 @@ impl Values {
   /// ```sql
   /// VALUES (1, 'one'), (2, 'two'), (3, 'three')
   /// ```
+  #[cfg(not(feature = "mysql"))]
   pub fn values(mut self, expression: &str) -> Self {
+    push_unique(&mut self._values, expression.trim().to_string());
+    self
+  }
+}
+
+#[cfg(feature = "mysql")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
+impl Values {
+  /// The `values` clause with the `row` constructor clause
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # use sql_query_builder as sql;
+  /// let values_query = sql::Values::new()
+  ///   .row("(1, 'one'), row(2, 'two')")
+  ///   .row("(3, 'three')")
+  ///   .as_string();
+  ///
+  /// # let expected = "VALUES ROW(1, 'one'), row(2, 'two'), ROW(3, 'three')";
+  /// # assert_eq!(expected, values_query);
+  /// ```
+  ///
+  /// Output
+  ///
+  /// ```sql
+  /// VALUES ROW(1, 'one'), row(2, 'two'), ROW(3, 'three')
+  /// ```
+  pub fn row(mut self, expression: &str) -> Self {
     push_unique(&mut self._values, expression.trim().to_string());
     self
   }

--- a/tests/clause_row_spec.rs
+++ b/tests/clause_row_spec.rs
@@ -1,0 +1,179 @@
+#[cfg(feature = "mysql")]
+mod insert_command {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn method_row_should_add_a_row_clause() {
+    let query = sql::Insert::new().row("('foo', 'Foo')").as_string();
+    let expected_query = "VALUES ROW('foo', 'Foo')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_accumulate_row_on_consecutive_calls() {
+    let query = sql::Insert::new()
+      .row("('foo', 'Foo')")
+      .row("('bar', 'Bar')")
+      .as_string();
+    let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_not_accumulate_row_when_expression_is_empty() {
+    let query = sql::Insert::new().row("").row("('bar', 'Bar')").row("").as_string();
+    let expected_query = "VALUES ROW('bar', 'Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_not_produce_the_values_clause_when_has_only_calls_with_empty_argument() {
+    let query = sql::Insert::new().row("").row("").as_string();
+    let expected_query = "";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_trim_space_of_the_argument() {
+    let query = sql::Insert::new().row("   ('Bar')  ").as_string();
+    let expected_query = "VALUES ROW('Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_not_accumulate_arguments_with_the_same_content() {
+    let query = sql::Insert::new()
+      .row("('bar', 'Bar')")
+      .row("('bar', 'Bar')")
+      .as_string();
+    let expected_query = "VALUES ROW('bar', 'Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_before_should_add_raw_sql_before_values_clause() {
+    let query = sql::Insert::new()
+      .raw_before(sql::InsertClause::Values, "insert into users (login, name)")
+      .row("('foo', 'Foo')")
+      .as_string();
+    let expected_query = "insert into users (login, name) VALUES ROW('foo', 'Foo')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_raw_after_should_add_raw_sql_after_values_clause() {
+    let query = sql::Insert::new()
+      .row("('baz', 'Baz')")
+      .raw_after(sql::InsertClause::Values, ", ROW('foo', 'Foo')")
+      .as_string();
+    let expected_query = "VALUES ROW('baz', 'Baz') , ROW('foo', 'Foo')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn clause_row_should_be_after_insert_into_clause() {
+    let query = sql::Insert::new()
+      .row("('bar', 'Bar')")
+      .insert_into("users (login, name)")
+      .as_string();
+    let expected_query = "INSERT INTO users (login, name) VALUES ROW('bar', 'Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+}
+
+#[cfg(feature = "mysql")]
+mod values_command {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn method_row_should_add_a_values_statement_with_the_row_constructor_clause() {
+    let query = sql::Values::new().row("('foo', 'Foo')").as_string();
+    let expected_query = "VALUES ROW('foo', 'Foo')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_accumulate_rows_on_consecutive_calls() {
+    let query = sql::Values::new()
+      .row("('foo', 'Foo')")
+      .row("('bar', 'Bar')")
+      .as_string();
+    let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_not_accumulate_row_when_expression_is_empty() {
+    let query = sql::Values::new().row("").row("('foo', 'Foo')").row("").as_string();
+    let expected_query = "VALUES ROW('foo', 'Foo')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_not_produce_values_statement_when_has_only_empty_rows() {
+    let query = sql::Values::new().row("").row("").as_string();
+    let expected_query = "";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_trim_space_of_the_argument() {
+    let query = sql::Values::new().row("   ('Bar')  ").as_string();
+    let expected_query = "VALUES ROW('Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_row_should_not_accumulate_arguments_with_the_same_content() {
+    let query = sql::Values::new()
+      .row("('bar', 'Bar')")
+      .row("('bar', 'Bar')")
+      .as_string();
+    let expected_query = "VALUES ROW('bar', 'Bar')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn when_call_raw_after_method_the_content_should_be_added_after_the_statement() {
+    let query = sql::Values::new()
+      .row("('foo', 'Foo')")
+      .row("('bar', 'Bar')")
+      .raw_before(sql::ValuesClause::Values, "insert into users (login, name)")
+      .as_string();
+    let expected_query = "\
+      insert into users (login, name) \
+      VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn when_call_raw_before_method_the_content_should_be_added_before_the_statement() {
+    let query = sql::Values::new()
+      .row("('foo', 'Foo')")
+      .row("('bar', 'Bar')")
+      .raw_after(sql::ValuesClause::Values, ", ROW('ros', 'Ros')")
+      .as_string();
+    let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar') , ROW('ros', 'Ros')";
+
+    assert_eq!(expected_query, query);
+  }
+}

--- a/tests/clause_values_spec.rs
+++ b/tests/clause_values_spec.rs
@@ -7,7 +7,7 @@ mod insert_command {
     let query = sql::Insert::new().values("('foo', 'Foo')").as_string();
     let expected_query = "VALUES ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -18,7 +18,7 @@ mod insert_command {
       .as_string();
     let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -30,7 +30,15 @@ mod insert_command {
       .as_string();
     let expected_query = "VALUES ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_values_should_not_produce_the_values_clause_when_has_only_calls_with_empty_argument() {
+    let query = sql::Insert::new().values("").values("").as_string();
+    let expected_query = "";
+
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -38,7 +46,7 @@ mod insert_command {
     let query = sql::Insert::new().values("   ('Bar')  ").as_string();
     let expected_query = "VALUES ('Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -49,7 +57,7 @@ mod insert_command {
       .as_string();
     let expected_query = "VALUES ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -60,7 +68,7 @@ mod insert_command {
       .as_string();
     let expected_query = "insert into users (login, name) VALUES ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -71,7 +79,7 @@ mod insert_command {
       .as_string();
     let expected_query = "VALUES ('baz', 'Baz') , ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -82,10 +90,11 @@ mod insert_command {
       .as_string();
     let expected_query = "INSERT INTO users (login, name) VALUES ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 }
 
+#[cfg(not(feature = "mysql"))]
 mod values_command {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;
@@ -95,7 +104,7 @@ mod values_command {
     let query = sql::Values::new().values("('foo', 'Foo')").as_string();
     let expected_query = "VALUES ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -106,11 +115,11 @@ mod values_command {
       .as_string();
     let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
-  fn method_values_should_not_accumulate_values_when_table_name_is_empty() {
+  fn method_values_should_not_accumulate_values_when_expression_is_empty() {
     let query = sql::Values::new()
       .values("")
       .values("('foo', 'Foo')")
@@ -118,7 +127,15 @@ mod values_command {
       .as_string();
     let expected_query = "VALUES ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
+  }
+
+  #[test]
+  fn method_values_should_not_produce_the_statement_when_has_only_calls_with_empty_argument() {
+    let query = sql::Values::new().values("").values("").as_string();
+    let expected_query = "";
+
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -126,7 +143,7 @@ mod values_command {
     let query = sql::Values::new().values("   ('Bar')  ").as_string();
     let expected_query = "VALUES ('Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -137,7 +154,7 @@ mod values_command {
       .as_string();
     let expected_query = "VALUES ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -148,7 +165,7 @@ mod values_command {
       .as_string();
     let expected_query = "insert into users (login, name) VALUES ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -159,6 +176,6 @@ mod values_command {
       .as_string();
     let expected_query = "VALUES ('baz', 'Baz') , ('foo', 'Foo')";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 }

--- a/tests/command_insert_spec.rs
+++ b/tests/command_insert_spec.rs
@@ -1,3 +1,126 @@
+mod full_api {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[cfg(not(any(feature = "sqlite", feature = "mysql")))]
+  #[test]
+  fn sql_standard_with_all_methods() {
+    let query = sql::Insert::new()
+      // required
+      .insert_into("users (login, name)")
+      // one of is required
+      .default_values()
+      .values("(1, 'one')")
+      .select(sql::Select::new().select("login, name"))
+      // optional
+      .overriding("user value")
+      .as_string();
+
+    let expected_query = "\
+      INSERT INTO users (login, name) \
+      OVERRIDING user value \
+      VALUES (1, 'one') \
+      SELECT login, name\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "postgresql")]
+  #[test]
+  fn postgres_with_all_methods() {
+    let query = sql::Insert::new()
+      // required
+      .insert_into("users (login, name)")
+      // one of is required
+      .default_values()
+      .values("(1, 'one')")
+      .select(sql::Select::new().select("login, name"))
+      // optional
+      .on_conflict("do nothing")
+      .overriding("user value")
+      .returning("login, name")
+      .with("foo", sql::Select::new().select("login, name"))
+      .as_string();
+
+    let expected_query = "\
+      WITH foo AS (SELECT login, name) \
+      INSERT INTO users (login, name) \
+      OVERRIDING user value \
+      VALUES (1, 'one') \
+      SELECT login, name \
+      ON CONFLICT do nothing \
+      RETURNING login, name\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "sqlite")]
+  #[test]
+  fn sqlite_with_all_methods() {
+    let query = sql::Insert::new()
+      // one of is required
+      .insert_into("users (login, name)")
+      .insert_or("abort into users (login, name)")
+      .replace_into("users (login, name)")
+      // one of is required
+      .default_values()
+      .values("(1, 'one')")
+      .select(sql::Select::new().select("login, name"))
+      // optional
+      .on_conflict("do nothing")
+      .returning("login, name")
+      .with("foo", sql::Select::new().select("login, name"))
+      .as_string();
+
+    let expected_query = "\
+      WITH foo AS (SELECT login, name) \
+      REPLACE INTO users (login, name) \
+      VALUES (1, 'one') \
+      SELECT login, name \
+      ON CONFLICT do nothing \
+      RETURNING login, name\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "mysql")]
+  #[test]
+  fn mysql_with_all_methods() {
+    let query = sql::Insert::new()
+      // one of is required
+      .insert_into("users (login, name)")
+      // methods below as a group
+      .insert("LOW_PRIORITY")
+      .into("users")
+      .column("login, name")
+      // one of is required
+      .values("(1, 'one')")
+      .row("('foo', 'Foo')")
+      .select(sql::Select::new().select("login, name"))
+      .set("name = 'Bar'")
+      // optional
+      .partition("p1")
+      .on_duplicate_key_update("c = c+1")
+      .as_string();
+
+    let expected_query = "\
+      INSERT LOW_PRIORITY \
+      INTO users \
+      PARTITION (p1) \
+      (login, name) \
+      SET name = 'Bar' \
+      VALUES ROW(1, 'one'), ROW('foo', 'Foo') \
+      SELECT login, name \
+      ON DUPLICATE KEY UPDATE c = c+1\
+    ";
+
+    assert_eq!(expected_query, query);
+  }
+}
+
 mod builder_features {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;
@@ -57,8 +180,8 @@ mod builder_features {
       /* test raw_after */\
     ";
 
-    assert_eq!(query_foo, expected_query_foo);
-    assert_eq!(query_foo_bar, expected_query_foo_bar);
+    assert_eq!(expected_query_foo, query_foo);
+    assert_eq!(expected_query_foo_bar, query_foo_bar);
   }
 
   #[test]
@@ -1005,6 +1128,24 @@ mod mysql_insert_variances {
       .insert_into("users (name)")
       .as_string();
     let expected_query = "INSERT INTO users (name)";
+
+    assert_eq!(expected_query, query);
+  }
+}
+
+#[cfg(feature = "mysql")]
+mod values_and_row_methods_mixed {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[test]
+  fn when_has_at_least_one_call_to_row_method_all_lines_should_receive_the_constructor_clause_row() {
+    let query = sql::Insert::new()
+      .values("('baz', 'Baz')")
+      .values("('foo', 'Foo')")
+      .row("('max', 'Max')")
+      .as_string();
+    let expected_query = "VALUES ROW('baz', 'Baz'), ROW('foo', 'Foo'), ROW('max', 'Max')";
 
     assert_eq!(expected_query, query);
   }

--- a/tests/command_values_spec.rs
+++ b/tests/command_values_spec.rs
@@ -1,100 +1,241 @@
+mod full_api {
+  use pretty_assertions::assert_eq;
+  use sql_query_builder as sql;
+
+  #[cfg(not(feature = "mysql"))]
+  #[test]
+  fn sql_standard_with_all_methods() {
+    let query = sql::Values::new().values("(1, 'one')").as_string();
+
+    let expected_query = "VALUES (1, 'one')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "postgresql")]
+  #[test]
+  fn postgres_with_all_methods() {
+    let query = sql::Values::new().values("(1, 'one')").as_string();
+
+    let expected_query = "VALUES (1, 'one')";
+
+    assert_eq!(expected_query, query);
+  }
+
+  #[cfg(feature = "mysql")]
+  #[test]
+  fn mysql_with_all_methods() {
+    let query = sql::Values::new().row("(1, 'one')").as_string();
+
+    let expected_query = "VALUES ROW(1, 'one')";
+
+    assert_eq!(expected_query, query);
+  }
+}
+
 mod builder_features {
   use pretty_assertions::assert_eq;
   use sql_query_builder as sql;
 
   #[test]
   fn values_builder_should_be_displayable() {
-    let values = sql::Values::new().values("('foo', 'Foo')").values("('bar', 'Bar')");
+    #[cfg(not(feature = "mysql"))]
+    {
+      let values = sql::Values::new().values("('foo', 'Foo')").values("('bar', 'Bar')");
 
-    println!("{}", values);
+      println!("{}", values);
 
-    let query = values.as_string();
-    let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
+      let query = values.as_string();
+      let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
 
-    assert_eq!(query, expected_query);
+      assert_eq!(expected_query, query);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let values = sql::Values::new().row("('foo', 'Foo')").row("('bar', 'Bar')");
+
+      println!("{}", values);
+
+      let query = values.as_string();
+      let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
   fn values_builder_should_be_debuggable() {
-    let values = sql::Values::new().values("('foo', 'Foo')").values("('bar', 'Bar')");
+    #[cfg(not(feature = "mysql"))]
+    {
+      let values = sql::Values::new().values("('foo', 'Foo')").values("('bar', 'Bar')");
 
-    println!("{:?}", values);
+      println!("{:?}", values);
 
-    let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
-    let query = values.as_string();
+      let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
+      let query = values.as_string();
 
-    assert_eq!(query, expected_query);
+      assert_eq!(expected_query, query);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let values = sql::Values::new().row("('foo', 'Foo')").row("('bar', 'Bar')");
+
+      println!("{:?}", values);
+
+      let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+      let query = values.as_string();
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
   fn values_builder_should_be_cloneable() {
-    let values_foo = sql::Values::new()
-      .raw("/* test raw */")
-      .raw_before(sql::ValuesClause::Values, "/* test raw_before */")
-      .values("('foo', 'Foo')")
-      .raw_after(sql::ValuesClause::Values, "/* test raw_after */");
+    #[cfg(not(feature = "mysql"))]
+    {
+      let values_foo = sql::Values::new()
+        .raw("/* test raw */")
+        .raw_before(sql::ValuesClause::Values, "/* test raw_before */")
+        .values("('foo', 'Foo')")
+        .raw_after(sql::ValuesClause::Values, "/* test raw_after */");
 
-    let values_foo_bar = values_foo.clone().values("('bar', 'Bar')");
+      let values_foo_bar = values_foo.clone().values("('bar', 'Bar')");
 
-    let query_foo = values_foo.as_string();
-    let query_foo_bar = values_foo_bar.as_string();
+      let query_foo = values_foo.as_string();
+      let query_foo_bar = values_foo_bar.as_string();
 
-    let expected_query_foo = "\
-      /* test raw */ \
-      /* test raw_before */ \
-      VALUES ('foo', 'Foo') \
-      /* test raw_after */\
-    ";
-    let expected_query_foo_bar = "\
-      /* test raw */ \
-      /* test raw_before */ \
-      VALUES ('foo', 'Foo'), ('bar', 'Bar') \
-      /* test raw_after */\
-    ";
+      let expected_query_foo = "\
+        /* test raw */ \
+        /* test raw_before */ \
+        VALUES ('foo', 'Foo') \
+        /* test raw_after */\
+      ";
+      let expected_query_foo_bar = "\
+        /* test raw */ \
+        /* test raw_before */ \
+        VALUES ('foo', 'Foo'), ('bar', 'Bar') \
+        /* test raw_after */\
+      ";
 
-    assert_eq!(query_foo, expected_query_foo);
-    assert_eq!(query_foo_bar, expected_query_foo_bar);
+      assert_eq!(expected_query_foo, query_foo);
+      assert_eq!(expected_query_foo_bar, query_foo_bar);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let values_foo = sql::Values::new()
+        .raw("/* test raw */")
+        .raw_before(sql::ValuesClause::Values, "/* test raw_before */")
+        .row("('foo', 'Foo')")
+        .raw_after(sql::ValuesClause::Values, "/* test raw_after */");
+
+      let values_foo_bar = values_foo.clone().row("('bar', 'Bar')");
+
+      let query_foo = values_foo.as_string();
+      let query_foo_bar = values_foo_bar.as_string();
+
+      let expected_query_foo = "\
+        /* test raw */ \
+        /* test raw_before */ \
+        VALUES ROW('foo', 'Foo') \
+        /* test raw_after */\
+      ";
+      let expected_query_foo_bar = "\
+        /* test raw */ \
+        /* test raw_before */ \
+        VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar') \
+        /* test raw_after */\
+      ";
+
+      assert_eq!(expected_query_foo, query_foo);
+      assert_eq!(expected_query_foo_bar, query_foo_bar);
+    }
   }
 
   #[test]
   fn values_builder_should_be_able_to_conditionally_add_clauses() {
-    let mut values = sql::Values::new().values("('foo', 'Foo')");
+    #[cfg(not(feature = "mysql"))]
+    {
+      let mut values = sql::Values::new().values("('foo', 'Foo')");
 
-    if true {
-      values = values.values("('bar', 'Bar')");
+      if true {
+        values = values.values("('bar', 'Bar')");
+      }
+
+      let query = values.as_string();
+      let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
+
+      assert_eq!(expected_query, query);
     }
 
-    let query = values.as_string();
-    let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
+    #[cfg(feature = "mysql")]
+    {
+      let mut values = sql::Values::new().row("('foo', 'Foo')");
 
-    assert_eq!(query, expected_query);
+      if true {
+        values = values.row("('bar', 'Bar')");
+      }
+
+      let query = values.as_string();
+      let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
   fn values_builder_should_be_composable() {
-    fn value_foo(values: sql::Values) -> sql::Values {
-      values.values("('foo', 'Foo')")
+    #[cfg(not(feature = "mysql"))]
+    {
+      fn value_foo(values: sql::Values) -> sql::Values {
+        values.values("('foo', 'Foo')")
+      }
+
+      fn value_bar(values: sql::Values) -> sql::Values {
+        values.values("('bar', 'Bar')")
+      }
+
+      fn as_string(values: sql::Values) -> String {
+        values.as_string()
+      }
+
+      let query = Some(sql::Values::new())
+        .map(value_foo)
+        .map(value_bar)
+        .map(as_string)
+        .unwrap();
+
+      let expected_query = "VALUES ('foo', 'Foo'), ('bar', 'Bar')";
+
+      assert_eq!(expected_query, query);
     }
 
-    fn value_bar(values: sql::Values) -> sql::Values {
-      values.values("('bar', 'Bar')")
+    #[cfg(feature = "mysql")]
+    {
+      fn value_foo(values: sql::Values) -> sql::Values {
+        values.row("('foo', 'Foo')")
+      }
+
+      fn value_bar(values: sql::Values) -> sql::Values {
+        values.row("('bar', 'Bar')")
+      }
+
+      fn as_string(values: sql::Values) -> String {
+        values.as_string()
+      }
+
+      let query = Some(sql::Values::new())
+        .map(value_foo)
+        .map(value_bar)
+        .map(as_string)
+        .unwrap();
+
+      let expected_query = "VALUES ROW('foo', 'Foo'), ROW('bar', 'Bar')";
+
+      assert_eq!(expected_query, query);
     }
-
-    fn as_string(values: sql::Values) -> String {
-      values.as_string()
-    }
-
-    let query = Some(sql::Values::new())
-      .map(value_foo)
-      .map(value_bar)
-      .map(as_string)
-      .unwrap();
-
-    let expected_query = "\
-      VALUES ('foo', 'Foo'), ('bar', 'Bar')\
-    ";
-
-    assert_eq!(query, expected_query);
   }
 }
 
@@ -107,7 +248,7 @@ mod builder_methods {
     let query = sql::Values::new().as_string();
     let expected_query = "";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -115,42 +256,86 @@ mod builder_methods {
     let query = sql::Values::new().as_string();
     let expected_query = "";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
   fn method_debug_should_print_at_console_in_a_human_readable_format() {
-    let query = sql::Values::new()
-      .values("(1, 'one')")
-      .values("(2, 'two')")
-      .debug()
-      .as_string();
-    let expected_query = "VALUES (1, 'one'), (2, 'two')";
+    #[cfg(not(feature = "mysql"))]
+    {
+      let query = sql::Values::new()
+        .values("(1, 'one')")
+        .values("(2, 'two')")
+        .debug()
+        .as_string();
+      let expected_query = "VALUES (1, 'one'), (2, 'two')";
 
-    assert_eq!(query, expected_query);
+      assert_eq!(expected_query, query);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let query = sql::Values::new()
+        .row("(1, 'one')")
+        .row("(2, 'two')")
+        .debug()
+        .as_string();
+      let expected_query = "VALUES ROW(1, 'one'), ROW(2, 'two')";
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
   fn method_print_should_print_in_one_line_the_current_state_of_builder() {
-    let query = sql::Values::new()
-      .values("(1, 'one')")
-      .values("(2, 'two')")
-      .print()
-      .as_string();
-    let expected_query = "VALUES (1, 'one'), (2, 'two')";
+    #[cfg(not(feature = "mysql"))]
+    {
+      let query = sql::Values::new()
+        .values("(1, 'one')")
+        .values("(2, 'two')")
+        .print()
+        .as_string();
+      let expected_query = "VALUES (1, 'one'), (2, 'two')";
 
-    assert_eq!(query, expected_query);
+      assert_eq!(expected_query, query);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let query = sql::Values::new()
+        .row("(1, 'one')")
+        .row("(2, 'two')")
+        .print()
+        .as_string();
+      let expected_query = "VALUES ROW(1, 'one'), ROW(2, 'two')";
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
   fn method_raw_should_add_raw_sql_on_top_of_the_command() {
-    let query = sql::Values::new()
-      .raw("/* the values command */")
-      .values("(1, 'one')")
-      .as_string();
-    let expected_query = "/* the values command */ VALUES (1, 'one')";
+    #[cfg(not(feature = "mysql"))]
+    {
+      let query = sql::Values::new()
+        .raw("/* the values command */")
+        .values("(1, 'one')")
+        .as_string();
+      let expected_query = "/* the values command */ VALUES (1, 'one')";
 
-    assert_eq!(query, expected_query);
+      assert_eq!(expected_query, query);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let query = sql::Values::new()
+        .raw("/* the values command */")
+        .row("(1, 'one')")
+        .as_string();
+      let expected_query = "/* the values command */ VALUES ROW(1, 'one')";
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
@@ -158,7 +343,7 @@ mod builder_methods {
     let query = sql::Values::new().raw("/* raw one */").raw("/* raw two */").as_string();
     let expected_query = "/* raw one */ /* raw two */";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -166,18 +351,32 @@ mod builder_methods {
     let query = sql::Values::new().raw("").raw("/* raw one */").raw("").as_string();
     let expected_query = "/* raw one */";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
   fn method_raw_should_be_the_first_to_be_concatenated() {
-    let query = sql::Values::new()
-      .values("(1, 'one')")
-      .raw("insert into my_table(num, txt)")
-      .as_string();
-    let expected_query = "insert into my_table(num, txt) VALUES (1, 'one')";
+    #[cfg(not(feature = "mysql"))]
+    {
+      let query = sql::Values::new()
+        .values("(1, 'one')")
+        .raw("insert into my_table(num, txt)")
+        .as_string();
+      let expected_query = "insert into my_table(num, txt) VALUES (1, 'one')";
 
-    assert_eq!(query, expected_query);
+      assert_eq!(expected_query, query);
+    }
+
+    #[cfg(feature = "mysql")]
+    {
+      let query = sql::Values::new()
+        .row("(1, 'one')")
+        .raw("insert into my_table(num, txt)")
+        .as_string();
+      let expected_query = "insert into my_table(num, txt) VALUES ROW(1, 'one')";
+
+      assert_eq!(expected_query, query);
+    }
   }
 
   #[test]
@@ -185,7 +384,7 @@ mod builder_methods {
     let query = sql::Values::new().raw("  /* raw one */  ").as_string();
     let expected_query = "/* raw one */";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -196,7 +395,7 @@ mod builder_methods {
       .as_string();
     let expected_query = "/* should not be repeat */";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -206,7 +405,7 @@ mod builder_methods {
       .as_string();
     let expected_query = "/* raw one */";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 
   #[test]
@@ -216,6 +415,6 @@ mod builder_methods {
       .as_string();
     let expected_query = "/* raw one */";
 
-    assert_eq!(query, expected_query);
+    assert_eq!(expected_query, query);
   }
 }


### PR DESCRIPTION
Basic API

```rust
// Insert builder
let query = sql::Insert::new()
  // one of is required
  .values("('foo', 'Foo')")
  .row("('foo', 'Foo')")
  .as_string();

// Values builder
let query = sql::Values::new()
  .row("(1, 'one')")
  .as_string();
```

Reference
- https://dev.mysql.com/doc/refman/8.4/en/values.html
- https://dev.mysql.com/doc/refman/8.4/en/insert.html