### PR TITLE
Insert builder: fix mutually exclusive methods

### DIFF
--- a/scripts/watch_test.sh
+++ b/scripts/watch_test.sh
@@ -8,6 +8,7 @@
 # ./scripts/watch_test.sh all        # will enable all feature
 # ./scripts/watch_test.sh postgresql # will enable only the postgresql feature
 
+clear
 all_features='postgresql sqlite mysql'
 features=''
 test_names=$(git status -s | grep 'A[[:space:]]*tests/\|M[[:space:]]*tests/' | sed -e 's/.* //' -e 's/tests\//--test /' -e 's/\.rs//' | tr '\n' ' ')

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -432,11 +432,13 @@ pub enum DropTableParams {
 #[derive(Default, Clone)]
 pub struct Insert {
   pub(crate) _insert_into: String,
+  pub(crate) _insert_variance: InsertVariance,
+  pub(crate) _raw: Vec<String>,
   pub(crate) _raw_after: Vec<(InsertClause, String)>,
   pub(crate) _raw_before: Vec<(InsertClause, String)>,
-  pub(crate) _raw: Vec<String>,
   pub(crate) _select: Option<Select>,
   pub(crate) _values: Vec<String>,
+  pub(crate) _values_variance: ValuesVariance,
 
   #[cfg(any(feature = "postgresql", feature = "sqlite"))]
   pub(crate) _on_conflict: String,
@@ -456,9 +458,6 @@ pub struct Insert {
   #[cfg(feature = "sqlite")]
   pub(crate) _replace_into: String,
 
-  #[cfg(not(feature = "mysql"))]
-  pub(crate) _default_values: bool,
-
   #[cfg(feature = "mysql")]
   pub(crate) _column: Vec<String>,
 
@@ -467,9 +466,6 @@ pub struct Insert {
 
   #[cfg(feature = "mysql")]
   pub(crate) _into: String,
-
-  #[cfg(feature = "mysql")]
-  pub(crate) _mysql_variance: MySqlVariance,
 
   #[cfg(feature = "mysql")]
   pub(crate) _on_duplicate_key_update: Vec<String>,
@@ -534,13 +530,34 @@ pub enum InsertClause {
   Set,
 }
 
-#[cfg(feature = "mysql")]
 #[derive(Default, PartialEq, Clone)]
-pub enum MySqlVariance {
+pub enum InsertVariance {
+  #[default]
+  InsertInto,
+
+  #[cfg(feature = "sqlite")]
+  InsertOr,
+
+  #[cfg(feature = "sqlite")]
+  ReplaceInto,
+
+  #[cfg(feature = "mysql")]
+  InsertSplitted,
+}
+
+#[derive(Default, PartialEq, Clone)]
+pub enum ValuesVariance {
   #[default]
   InsertValues,
   InsertSelect,
+
+  #[cfg(not(feature = "mysql"))]
+  InsertDefaultValues,
+
+  #[cfg(feature = "mysql")]
   InsertSet,
+
+  #[cfg(feature = "mysql")]
   InsertValuesRow,
 }
 

--- a/tests/command_insert_spec.rs
+++ b/tests/command_insert_spec.rs
@@ -19,7 +19,6 @@ mod full_api {
     let expected_query = "\
       INSERT INTO users (login, name) \
       OVERRIDING user value \
-      VALUES (1, 'one') \
       SELECT login, name\
     ";
 
@@ -47,7 +46,6 @@ mod full_api {
       WITH foo AS (SELECT login, name) \
       INSERT INTO users (login, name) \
       OVERRIDING user value \
-      VALUES (1, 'one') \
       SELECT login, name \
       ON CONFLICT do nothing \
       RETURNING login, name\
@@ -77,7 +75,6 @@ mod full_api {
     let expected_query = "\
       WITH foo AS (SELECT login, name) \
       REPLACE INTO users (login, name) \
-      VALUES (1, 'one') \
       SELECT login, name \
       ON CONFLICT do nothing \
       RETURNING login, name\


### PR DESCRIPTION
# Mutually exclusive methods on Insert builder

Avaliable on `sqlite` only

Methods `Insert::insert_into`, `Insert::insert_or` and `Insert::replace_into` are mutually exclusive, the last called will overrides the previous ones.

```rust
#[cfg(feature = "sqlite")]
{
  use sql_query_builder as sql;

  let insert = sql::Insert::new()
    .insert_into("users (login, name)")
    .replace_into("users (login, name)")
    .as_string();
}
```
Output

```sql
REPLACE INTO users (login, name)
```

Avaliable on `mysql` only

Methods `Insert::insert_into` and the splitted version (`Insert::insert`, `Insert::into`, `Insert::column`) are mutually exclusive, the last called will overrides the previous ones.

```rust
#[cfg(feature = "mysql")]
{
  use sql_query_builder as sql;

  let insert = sql::Insert::new()
    .insert_into("users (login, name)")
    .insert("low_priority")
    .into("users")
    .column("login")
    .as_string();
}
```
Output

```sql
INSERT low_priority INTO users (login)
```